### PR TITLE
Add simple npm workflow scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,29 @@
 {
-  "name": "Freespirits",
+  "name": "freespirits",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "freespirits",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "chalk": "^5.3.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "freespirits",
+  "version": "1.0.0",
+  "description": "Utility scripts to demonstrate a simple dev/build/preview workflow.",
+  "type": "module",
+  "scripts": {
+    "dev": "node scripts/dev.js",
+    "build": "node scripts/build.js",
+    "preview": "node scripts/preview.js"
+  },
+  "keywords": [
+    "workflow",
+    "demo"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "chalk": "^5.3.0"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,39 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import chalk from 'chalk';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const appInfoPath = path.join(rootDir, 'src', 'app-info.json');
+const distDir = path.join(rootDir, 'dist');
+const outputPath = path.join(distDir, 'summary.txt');
+
+async function main() {
+  console.log(chalk.cyan('\n🏗️  Building Freespirits workflow summary...'));
+
+  const rawData = await readFile(appInfoPath, 'utf8');
+  const appInfo = JSON.parse(rawData);
+
+  await mkdir(distDir, { recursive: true });
+
+  const lines = [
+    `${appInfo.name} (v${appInfo.version})`,
+    appInfo.description,
+    '',
+    'Workflow steps:',
+    ...appInfo.steps.map((step, index) => `${index + 1}. ${step.title} [${step.id}]\n${step.details}`),
+    '',
+    `Generated: ${new Date().toISOString()}`
+  ];
+
+  await writeFile(outputPath, lines.join('\n'), 'utf8');
+
+  console.log(chalk.green(`\n✅  Summary written to ${path.relative(rootDir, outputPath)}\n`));
+}
+
+main().catch(error => {
+  console.error(chalk.red('\n❌  Build failed.'));
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import chalk from 'chalk';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const appInfoPath = path.join(rootDir, 'src', 'app-info.json');
+
+async function main() {
+  console.log(chalk.cyan('\n🔧  Freespirits development readiness check'));
+
+  const rawData = await readFile(appInfoPath, 'utf8');
+  const appInfo = JSON.parse(rawData);
+
+  console.log(chalk.white(`\nProject: ${chalk.bold(appInfo.name)}`));
+  console.log(chalk.white(`Version: ${chalk.bold(appInfo.version)}`));
+  console.log(chalk.white(`Maintainer: ${chalk.bold(appInfo.maintainer)}`));
+  console.log(chalk.gray(`\n${appInfo.description}\n`));
+
+  console.log(chalk.magenta('Configured workflow steps:'));
+  for (const [index, step] of appInfo.steps.entries()) {
+    const counter = chalk.yellow(String(index + 1).padStart(2, '0'));
+    console.log(`${counter}. ${chalk.bold(step.title)} — ${step.details}`);
+  }
+
+  console.log(chalk.green('\n✨  Configuration looks good. You can run "npm run build" next.\n'));
+}
+
+main().catch(error => {
+  console.error(chalk.red('\n❌  Development check failed.'));
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import chalk from 'chalk';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const outputPath = path.join(rootDir, 'dist', 'summary.txt');
+
+async function main() {
+  console.log(chalk.cyan('\n👀  Previewing build output...\n'));
+
+  let contents;
+  try {
+    contents = await readFile(outputPath, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(chalk.red('No build artifacts found. Have you run "npm run build"?'));
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  console.log(chalk.white(contents));
+  console.log(chalk.green('\n✅  Preview complete.\n'));
+}
+
+main().catch(error => {
+  console.error(chalk.red('\n❌  Preview failed.'));
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/app-info.json
+++ b/src/app-info.json
@@ -1,0 +1,23 @@
+{
+  "name": "Freespirits Utility Workflow",
+  "version": "1.0.0",
+  "description": "A lightweight Node-based workflow that demonstrates npm scripts for development, building, and previewing output.",
+  "maintainer": "Floopy",
+  "steps": [
+    {
+      "id": "dev",
+      "title": "Development readiness check",
+      "details": "Validates that the project metadata is accessible before running a build."
+    },
+    {
+      "id": "build",
+      "title": "Build artifact generation",
+      "details": "Transforms the project metadata into a distributable summary file in the dist directory."
+    },
+    {
+      "id": "preview",
+      "title": "Preview generated output",
+      "details": "Displays the contents of the generated summary file as a quick preview."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a package.json with npm scripts for dev, build, and preview workflows
- implement node-based scripts that read project metadata and generate a summary artifact
- ignore build artifacts and node_modules via a new .gitignore entry

## Testing
- npm install
- npm run dev
- npm run build
- npm run preview

------
https://chatgpt.com/codex/tasks/task_e_68d87e4dbe548327a1cc72c28d7702df