### PR TITLE
Add Vercel gateway for Cloudflare AI briefing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ functions/
 
    When prompted, select the Pages project you configured above. Wrangler will reuse the environment variables defined in the dashboard.
 
+## Deploying to Vercel
+
+1. Create a new Vercel project and import this repository.
+2. In the Vercel dashboard, add the following Environment Variables (recommended scope: **Production** and **Preview**):
+   - `CLOUDFLARE_ACCOUNT_ID` → `e8823131dce5e3dcaedec59bb4f7c093`
+   - `CLOUDFLARE_AI_TOKEN` → the Cloudflare API token with **Workers AI** permissions (do **not** commit the token to git).
+3. Deploy the project. Vercel will serve the static assets in `public/` and expose the `/api/briefing` Serverless Function defined in `api/briefing.js`.
+4. The front-end uses the same `/api/briefing` path, so no additional configuration is required after the environment variables are set.
+
 ## Updating integrations
 
 - **Daily Briefing**: The front end calls `/api/briefing`, which in turn invokes Cloudflare's `@cf/meta/llama-3-8b-instruct` model. Adjust the prompt in `functions/api/briefing.js` or point it at a different [Cloudflare AI model](https://developers.cloudflare.com/workers-ai/models/) by changing the endpoint path.

--- a/api/briefing.js
+++ b/api/briefing.js
@@ -1,0 +1,62 @@
+export default async function handler(request, response) {
+    if (request.method !== 'GET') {
+        response.setHeader('Allow', 'GET');
+        return response.status(405).json({ error: 'Method not allowed. Use GET.' });
+    }
+
+    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+    const apiToken = process.env.CLOUDFLARE_AI_TOKEN;
+
+    if (!accountId || !apiToken) {
+        return response.status(500).json({ error: 'Cloudflare AI environment variables are not configured.' });
+    }
+
+    const systemPrompt = 'You are a world-class cybersecurity intelligence analyst. Provide concise daily threat intel.';
+    const userPrompt =
+        "Summarize today's most significant cybersecurity developments. Include:\n\n" +
+        '1. One major, publicly disclosed data breach.\n' +
+        '2. One new or updated tool relevant to ethical hacking or defense.\n' +
+        '3. One significant update to a major security operating system like Kali Linux or Parrot OS.\n\n' +
+        'Format the response with headings for "Recent Data Breaches", "New Tools & Exploits", and "Platform Updates".';
+
+    try {
+        const aiResponse = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/@cf/meta/llama-3-8b-instruct`,
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${apiToken}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    messages: [
+                        { role: 'system', content: systemPrompt },
+                        { role: 'user', content: userPrompt },
+                    ],
+                }),
+            }
+        );
+
+        if (!aiResponse.ok) {
+            const errorText = await aiResponse.text();
+            throw new Error(`Cloudflare AI error: ${aiResponse.status} ${aiResponse.statusText} - ${errorText}`);
+        }
+
+        const result = await aiResponse.json();
+        const aiText =
+            result?.result?.response ??
+            result?.result?.output_text ??
+            result?.result?.text ??
+            result?.result ??
+            null;
+
+        if (!aiText || typeof aiText !== 'string') {
+            throw new Error('Unexpected response from Cloudflare AI');
+        }
+
+        return response.status(200).json({ markdown: aiText });
+    } catch (error) {
+        console.error('Daily briefing gateway error:', error);
+        return response.status(500).json({ error: 'Failed to retrieve intelligence briefing. Check server logs for details.' });
+    }
+}


### PR DESCRIPTION
## Summary
- add a Vercel-compatible `/api/briefing` serverless function that proxies Cloudflare Workers AI
- document Vercel deployment steps and required environment variables in the README

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dc1448ba58832792cd172766da00e5