### PR TITLE
Add external resource links to Arsenal page

### DIFF
--- a/public/arsenal.html
+++ b/public/arsenal.html
@@ -37,36 +37,80 @@
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
                         An open-source, Debian-based Linux distribution geared towards various information security tasks, such as penetration testing, security research, computer forensics, and reverse engineering. It comes pre-installed with over 600 penetration-testing programs.
                     </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://www.kali.org/" target="_blank" rel="noopener noreferrer">
+                            <span>Visit Official Site</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
                 </article>
                 <article class="data-card">
                     <p class="font-mono" style="font-size: 1.5rem; color: rgba(204,255,204,0.95);">Parrot OS</p>
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
                         A free and open-source Linux distribution based on Debian with a focus on security, privacy, and development. It includes a full portable laboratory for security and digital forensics experts, but it also includes all you need to develop your own software or keep your data secure.
                     </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://www.parrotsec.org/" target="_blank" rel="noopener noreferrer">
+                            <span>Explore Parrot OS</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
                 </article>
                 <article class="data-card">
                     <p class="font-mono" style="font-size: 1.5rem; color: rgba(204,255,204,0.95);">Mobile Security &amp; Auditing</p>
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        For developers and security professionals, specialized applications like Stryker exist for rooted Android systems to enable deep-level wireless network auditing and analysis. These tools provide granular control for testing network security but require expert knowledge and explicit permissions to operate legally and ethically.
+                        For developers and security professionals, specialized applications for rooted Android systems enable deep-level wireless network auditing and analysis. Frameworks like the Mobile Security Framework (MobSF) support comprehensive assessments across Android and iOS, while advanced toolkits demand expert knowledge and explicit permissions to operate legally and ethically.
                     </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://mobsf.github.io/docs/#/" target="_blank" rel="noopener noreferrer">
+                            <span>MobSF Documentation</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                        <a class="resource-link" href="https://github.com/MobSF/Mobile-Security-Framework-MobSF" target="_blank" rel="noopener noreferrer">
+                            <span>MobSF on GitHub</span>
+                            <i data-lucide="github"></i>
+                        </a>
+                    </div>
                 </article>
                 <article class="data-card">
                     <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">Nmap (Network Mapper)</p>
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
                         A free and open-source utility for network discovery and security auditing. It's used to discover hosts and services on a computer network by sending packets and analyzing the responses.
                     </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://nmap.org/" target="_blank" rel="noopener noreferrer">
+                            <span>Access Nmap</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
                 </article>
                 <article class="data-card">
                     <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">Wireshark</p>
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
                         A widely-used network protocol analyzer. It lets you see what's happening on your network at a microscopic level and is the de facto standard across many industries for troubleshooting and analysis.
                     </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://www.wireshark.org/" target="_blank" rel="noopener noreferrer">
+                            <span>Download Wireshark</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
                 </article>
                 <article class="data-card">
                     <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">Metasploit Framework</p>
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
                         An open-source penetration testing framework. Security professionals use it to probe for systematic vulnerabilities on networks and servers to verify and validate security defenses.
                     </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://www.metasploit.com/" target="_blank" rel="noopener noreferrer">
+                            <span>Metasploit Platform</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                        <a class="resource-link" href="https://github.com/rapid7/metasploit-framework" target="_blank" rel="noopener noreferrer">
+                            <span>Metasploit on GitHub</span>
+                            <i data-lucide="github"></i>
+                        </a>
+                    </div>
                 </article>
             </div>
         </section>

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -140,6 +140,39 @@ nav {
     box-shadow: 0 0 20px var(--color-neon-secondary), 0 0 40px rgba(0, 204, 68, 0.25);
 }
 
+.resource-actions {
+    margin-top: 1.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.resource-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 0.95rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(0, 255, 136, 0.35);
+    background: rgba(0, 0, 0, 0.2);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
+}
+
+.resource-link:hover {
+    border-color: var(--color-neon-primary);
+    box-shadow: 0 0 16px rgba(0, 255, 136, 0.4);
+    transform: translateY(-2px);
+}
+
+.resource-link i {
+    width: 1rem;
+    height: 1rem;
+}
+
 .font-mono {
     font-family: 'Roboto Mono', monospace;
 }


### PR DESCRIPTION
## Summary
- add official resource links for Kali Linux, Parrot OS, Wireshark, Nmap, Metasploit, and mobile auditing resources on the Arsenal page
- introduce styled resource link buttons and update copy around mobile auditing guidance
- create styling for the new resource links to match the site's neon theme

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dd00b7a34c8327ba4776bf8d932656