### PR TITLE
Add caching and metadata to AI daily briefing

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -348,3 +348,27 @@ button:hover {
 .text-strong {
     color: rgba(204, 255, 204, 1);
 }
+
+.briefing-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.meta-pill {
+    background: rgba(0, 255, 136, 0.12);
+    border: 1px solid rgba(0, 255, 136, 0.35);
+    border-radius: 9999px;
+    padding: 0.35rem 0.9rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.meta-timestamp {
+    padding-left: 0.5rem;
+    border-left: 2px solid rgba(0, 255, 136, 0.3);
+}

--- a/public/assets/js/briefing.js
+++ b/public/assets/js/briefing.js
@@ -9,7 +9,7 @@ async function fetchDailyBriefing() {
         const payload = await response.json();
 
         if (payload?.markdown) {
-            renderBriefing(payload.markdown);
+            renderBriefing(payload.markdown, payload.generatedAt);
         } else {
             throw new Error('Malformed response payload');
         }
@@ -19,7 +19,7 @@ async function fetchDailyBriefing() {
     }
 }
 
-function renderBriefing(rawText) {
+function renderBriefing(rawText, generatedAt) {
     const container = document.getElementById('briefing-content');
     if (!container) return;
 
@@ -29,13 +29,37 @@ function renderBriefing(rawText) {
         .replace(/\* ([^*]+)/g, '<p class="briefing-paragraph">$1</p>')
         .replace(/\n/g, '<br>');
 
-    container.innerHTML = `<div class="data-card">${htmlContent}</div>`;
+    const metaBlock = [
+        '<div class="briefing-meta font-mono">',
+        '<span class="meta-pill">Automated refresh every 2 hours</span>',
+        generatedAt ? `<span class="meta-timestamp">Last updated: ${formatTimestamp(generatedAt)}</span>` : '',
+        '</div>',
+    ].join('');
+
+    container.innerHTML = `<div class="data-card">${metaBlock}${htmlContent}</div>`;
 }
 
 function renderError(message) {
     const container = document.getElementById('briefing-content');
     if (container) {
         container.innerHTML = `<p class="font-mono" style="color: #f87171; text-align: center;">${message}</p>`;
+    }
+}
+
+function formatTimestamp(isoString) {
+    try {
+        const date = new Date(isoString);
+        if (Number.isNaN(date.getTime())) {
+            return isoString;
+        }
+
+        return new Intl.DateTimeFormat(undefined, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        }).format(date);
+    } catch (error) {
+        console.warn('Unable to format timestamp:', error);
+        return isoString;
     }
 }
 


### PR DESCRIPTION
## Summary
- cache AI-powered daily briefing responses for two hours via the edge cache
- include a generated timestamp in the API response and show refresh cadence on the briefing card
- style the new metadata banner so update timing information matches the cyber aesthetic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd11f172e08327ba30b0309c689da4