### PR TITLE
Add unit tests for daily briefing function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,12 @@
 {
-  "name": "Freespirits",
+  "name": "freespirits",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "freespirits",
+      "version": "1.0.0"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "freespirits",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -348,3 +348,27 @@ button:hover {
 .text-strong {
     color: rgba(204, 255, 204, 1);
 }
+
+.briefing-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.meta-pill {
+    background: rgba(0, 255, 136, 0.12);
+    border: 1px solid rgba(0, 255, 136, 0.35);
+    border-radius: 9999px;
+    padding: 0.35rem 0.9rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.meta-timestamp {
+    padding-left: 0.5rem;
+    border-left: 2px solid rgba(0, 255, 136, 0.3);
+}

--- a/public/assets/js/briefing.js
+++ b/public/assets/js/briefing.js
@@ -9,7 +9,7 @@ async function fetchDailyBriefing() {
         const payload = await response.json();
 
         if (payload?.markdown) {
-            renderBriefing(payload.markdown);
+            renderBriefing(payload.markdown, payload.generatedAt);
         } else {
             throw new Error('Malformed response payload');
         }
@@ -19,7 +19,7 @@ async function fetchDailyBriefing() {
     }
 }
 
-function renderBriefing(rawText) {
+function renderBriefing(rawText, generatedAt) {
     const container = document.getElementById('briefing-content');
     if (!container) return;
 
@@ -29,13 +29,37 @@ function renderBriefing(rawText) {
         .replace(/\* ([^*]+)/g, '<p class="briefing-paragraph">$1</p>')
         .replace(/\n/g, '<br>');
 
-    container.innerHTML = `<div class="data-card">${htmlContent}</div>`;
+    const metaBlock = [
+        '<div class="briefing-meta font-mono">',
+        '<span class="meta-pill">Automated refresh every 2 hours</span>',
+        generatedAt ? `<span class="meta-timestamp">Last updated: ${formatTimestamp(generatedAt)}</span>` : '',
+        '</div>',
+    ].join('');
+
+    container.innerHTML = `<div class="data-card">${metaBlock}${htmlContent}</div>`;
 }
 
 function renderError(message) {
     const container = document.getElementById('briefing-content');
     if (container) {
         container.innerHTML = `<p class="font-mono" style="color: #f87171; text-align: center;">${message}</p>`;
+    }
+}
+
+function formatTimestamp(isoString) {
+    try {
+        const date = new Date(isoString);
+        if (Number.isNaN(date.getTime())) {
+            return isoString;
+        }
+
+        return new Intl.DateTimeFormat(undefined, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        }).format(date);
+    } catch (error) {
+        console.warn('Unable to format timestamp:', error);
+        return isoString;
     }
 }
 

--- a/tests/briefing.test.js
+++ b/tests/briefing.test.js
@@ -1,0 +1,98 @@
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { onRequestGet } from '../functions/api/briefing.js';
+
+const originalFetch = globalThis.fetch;
+const originalCaches = globalThis.caches;
+
+beforeEach(() => {
+    const store = new Map();
+
+    globalThis.caches = {
+        default: {
+            async match(request) {
+                return store.get(request.url) ?? null;
+            },
+            async put(request, response) {
+                store.set(request.url, response);
+            },
+        },
+    };
+
+    globalThis.fetch = async () =>
+        new Response(
+            JSON.stringify({
+                result: {
+                    response: '### Recent Data Breaches\n* breach detail',
+                },
+            }),
+            {
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+});
+
+after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalCaches === undefined) {
+        delete globalThis.caches;
+    } else {
+        globalThis.caches = originalCaches;
+    }
+});
+
+test('onRequestGet returns AI response payload and caches the result', async () => {
+    const waitUntilPromises = [];
+    const fetchCalls = [];
+
+    globalThis.fetch = async (...args) => {
+        fetchCalls.push(args);
+        return new Response(
+            JSON.stringify({
+                result: {
+                    response: '### Recent Data Breaches\n* breach detail',
+                },
+            }),
+            {
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+    };
+
+    const context = {
+        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
+        request: new Request('https://example.com/api/briefing'),
+        waitUntil(promise) {
+            waitUntilPromises.push(promise);
+        },
+    };
+
+    const response = await onRequestGet(context);
+    assert.equal(response.status, 200);
+
+    const body = await response.clone().json();
+    assert.equal(body.markdown, '### Recent Data Breaches\n* breach detail');
+    assert.ok(typeof body.generatedAt === 'string' && body.generatedAt.length > 0);
+    assert.doesNotThrow(() => new Date(body.generatedAt));
+
+    await Promise.all(waitUntilPromises);
+
+    const cachedResponse = await caches.default.match(new Request('https://example.com/api/briefing'));
+    assert.ok(cachedResponse, 'cache should contain a cloned response');
+
+    const secondResponse = await onRequestGet({ ...context, waitUntil: () => {} });
+    assert.equal(fetchCalls.length, 1, 'AI fetch should only happen once');
+    assert.equal((await secondResponse.clone().json()).markdown, body.markdown);
+});
+
+test('onRequestGet fails when AI credentials are missing', async () => {
+    const response = await onRequestGet({
+        env: {},
+        request: new Request('https://example.com/api/briefing'),
+    });
+
+    assert.equal(response.status, 500);
+    const payload = await response.clone().json();
+    assert.match(payload.error, /not configured/i);
+});


### PR DESCRIPTION
## Summary
- cache AI-powered daily briefing responses for two hours via the edge cache
- include a generated timestamp in the API response and show refresh cadence on the briefing card
- style the new metadata banner so update timing information matches the cyber aesthetic
- add unit tests that exercise the daily briefing function, covering cache hits and missing credential failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd11f172e08327ba30b0309c689da4