### PR TITLE
Add active chat headline to homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,12 @@
                 </a>
             </div>
         </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="message-circle"></i> Active Chat: Memorable Text Entry</h2>
+            <p class="highlight">
+                Engage with the HackTech community through our active chat hub. Drop in memorable intel, share defensive tactics, and keep the conversation thriving with every text you enter.
+            </p>
+        </section>
         <footer>
             <div class="socials">
                 <a href="https://facebook.com/YOUR_PAGE_HERE" target="_blank" rel="noopener noreferrer" aria-label="Facebook">


### PR DESCRIPTION
## Summary
- add an Active Chat headline panel to the homepage to highlight the community chat experience

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd2495ea148327a029b2508f7baf03