### PR TITLE
Wire active chat to Cloudflare AI

### DIFF
--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -1,0 +1,100 @@
+const SYSTEM_PROMPT = `You are Operative Lynx, an elite cyber threat analyst embedded with the HackTech collective. \
+Reply in 1-3 concise sentences, combining tactical insight with actionable next steps. Keep the tone composed, professional, and supportive.`;
+
+const ERROR_MESSAGE = 'Unable to reach the allied intelligence network right now.';
+const MAX_HISTORY = 12;
+
+const sanitizeHistory = (history) => {
+    if (!Array.isArray(history)) {
+        return [];
+    }
+
+    return history
+        .filter((entry) => entry && typeof entry.content === 'string' && typeof entry.role === 'string')
+        .map((entry) => ({
+            role: entry.role === 'assistant' ? 'assistant' : 'user',
+            content: entry.content.trim(),
+        }))
+        .filter((entry) => entry.content.length > 0)
+        .slice(-MAX_HISTORY);
+};
+
+export async function onRequestPost(context) {
+    const { request, env } = context;
+
+    const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+    const apiToken = env.CLOUDFLARE_AI_TOKEN;
+
+    if (!accountId || !apiToken) {
+        return new Response(
+            JSON.stringify({ error: 'Cloudflare AI environment variables are not configured.' }),
+            {
+                status: 500,
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+    }
+
+    let body;
+    try {
+        body = await request.json();
+    } catch (error) {
+        return new Response(JSON.stringify({ error: 'Invalid JSON payload.' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    const history = sanitizeHistory(body?.history);
+
+    if (history.length === 0) {
+        return new Response(JSON.stringify({ error: 'Conversation history is required.' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    const messages = [{ role: 'system', content: SYSTEM_PROMPT }, ...history];
+
+    try {
+        const aiResponse = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/@cf/meta/llama-3-8b-instruct`,
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${apiToken}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ messages }),
+            }
+        );
+
+        if (!aiResponse.ok) {
+            const errorText = await aiResponse.text();
+            throw new Error(`Cloudflare AI error: ${aiResponse.status} ${aiResponse.statusText} - ${errorText}`);
+        }
+
+        const result = await aiResponse.json();
+        const reply =
+            result?.result?.response ??
+            result?.result?.output_text ??
+            result?.result?.text ??
+            result?.result ??
+            null;
+
+        if (!reply || typeof reply !== 'string') {
+            throw new Error('Unexpected response from Cloudflare AI');
+        }
+
+        return new Response(
+            JSON.stringify({ reply: reply.trim() }),
+            { headers: { 'content-type': 'application/json' } }
+        );
+    } catch (error) {
+        console.error('Active chat function error:', error);
+        return new Response(
+            JSON.stringify({ error: ERROR_MESSAGE }),
+            { status: 502, headers: { 'content-type': 'application/json' } }
+        );
+    }
+}

--- a/public/assets/css/chat.css
+++ b/public/assets/css/chat.css
@@ -1,0 +1,243 @@
+.chat-shell {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.chat-noscript {
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    border: 1px dashed rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.5);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    letter-spacing: 0.06em;
+}
+
+.chat-window {
+    min-height: clamp(16rem, 24vw, 22rem);
+    max-height: 24rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(0, 255, 136, 0.25);
+    background: rgba(0, 15, 8, 0.65);
+    backdrop-filter: blur(6px);
+    padding: 1.1rem 1.25rem;
+    overflow-y: auto;
+    box-shadow: inset 0 0 30px rgba(0, 255, 136, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+}
+
+.chat-window::-webkit-scrollbar {
+    width: 0.35rem;
+}
+
+.chat-window::-webkit-scrollbar-thumb {
+    background: rgba(0, 255, 136, 0.45);
+    border-radius: 9999px;
+}
+
+.chat-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.chat-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    letter-spacing: 0.06em;
+    color: rgba(148, 163, 184, 0.7);
+}
+
+.chat-status-indicator {
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 9999px;
+    display: inline-block;
+    background: rgba(148, 163, 184, 0.6);
+    box-shadow: 0 0 6px rgba(148, 163, 184, 0.3);
+}
+
+.chat-clear {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border: 1px solid rgba(0, 255, 136, 0.3);
+    border-radius: 0.65rem;
+    padding: 0.4rem 0.8rem;
+    background: rgba(15, 23, 42, 0.5);
+    color: rgba(204, 255, 204, 0.85);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-clear:hover {
+    transform: translateY(-1px);
+    border-color: rgba(0, 255, 136, 0.6);
+    box-shadow: 0 0 12px rgba(0, 255, 136, 0.25);
+}
+
+.chat-entry {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.chat-label {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    color: rgba(204, 255, 204, 0.8);
+}
+
+.chat-controls {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.chat-controls input[type='text'] {
+    flex: 1 1 auto;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(0, 255, 136, 0.35);
+    background: rgba(0, 0, 0, 0.45);
+    color: rgba(224, 255, 224, 0.95);
+    padding: 0.75rem 1rem;
+    font-family: 'Roboto Mono', monospace;
+    letter-spacing: 0.04em;
+    font-size: 0.9rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-controls input[type='text']::placeholder {
+    color: rgba(226, 232, 240, 0.45);
+}
+
+.chat-controls input[type='text']:focus {
+    outline: none;
+    border-color: var(--color-neon-primary);
+    box-shadow: 0 0 12px rgba(0, 255, 136, 0.25);
+}
+
+.chat-controls input[type='text']:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    border-color: rgba(148, 163, 184, 0.35);
+    box-shadow: none;
+}
+
+.chat-send {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.75rem 1.2rem;
+    border-radius: 0.75rem;
+    background: linear-gradient(90deg, rgba(0, 255, 136, 0.9), rgba(59, 130, 246, 0.75));
+    border: none;
+    color: #020617;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    box-shadow: 0 12px 25px rgba(0, 255, 136, 0.2);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-send i,
+.chat-clear i {
+    width: 1rem;
+    height: 1rem;
+}
+
+.chat-send:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 32px rgba(0, 255, 136, 0.3);
+}
+
+.chat-send:disabled,
+.chat-send[aria-disabled='true'] {
+    cursor: not-allowed;
+    opacity: 0.65;
+    transform: none;
+    box-shadow: none;
+}
+
+.chat-message {
+    display: grid;
+    gap: 0.35rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(0, 255, 136, 0.18);
+    background: rgba(4, 16, 12, 0.75);
+    font-family: 'Roboto Mono', monospace;
+}
+
+.chat-message--user {
+    margin-left: auto;
+    border-color: rgba(59, 130, 246, 0.4);
+    background: rgba(30, 64, 175, 0.25);
+    box-shadow: 0 0 16px rgba(59, 130, 246, 0.15);
+}
+
+.chat-message--ally {
+    margin-right: auto;
+    border-color: rgba(34, 197, 94, 0.45);
+    background: rgba(6, 78, 59, 0.35);
+    box-shadow: 0 0 16px rgba(34, 197, 94, 0.18);
+}
+
+.chat-message--system {
+    margin: 0 auto;
+    border-style: dashed;
+    border-color: rgba(148, 163, 184, 0.35);
+    color: rgba(226, 232, 240, 0.85);
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.chat-author {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.75);
+}
+
+.chat-message p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: rgba(226, 255, 226, 0.9);
+}
+
+.chat-message time {
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.6);
+    justify-self: flex-end;
+}
+
+.chat-shell button {
+    letter-spacing: 0.15em;
+}
+
+@media (max-width: 720px) {
+    .chat-meta {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .chat-controls {
+        flex-direction: column;
+    }
+
+    .chat-send {
+        width: 100%;
+    }
+}

--- a/public/assets/js/chat.js
+++ b/public/assets/js/chat.js
@@ -1,0 +1,211 @@
+const statusStyles = {
+    idle: {
+        color: 'rgba(148, 163, 184, 0.6)',
+        glow: '0 0 10px rgba(148, 163, 184, 0.4)',
+        label: 'Standing by',
+    },
+    listening: {
+        color: 'var(--color-neon-primary)',
+        glow: '0 0 12px rgba(0, 255, 136, 0.6)',
+        label: 'Listening',
+    },
+    responding: {
+        color: 'rgba(59, 130, 246, 0.8)',
+        glow: '0 0 12px rgba(59, 130, 246, 0.6)',
+        label: 'Routing reply',
+    },
+};
+
+const HISTORY_LIMIT = 12;
+
+const formatTimestamp = (date = new Date()) =>
+    date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+export const initActiveChat = () => {
+    const chatShell = document.querySelector('[data-chat-shell]');
+    if (!chatShell) {
+        return;
+    }
+
+    const chatForm = chatShell.querySelector('#activeChatForm');
+    const chatInput = chatShell.querySelector('#activeChatInput');
+    const chatLog = chatShell.querySelector('#activeChatLog');
+    const chatReset = chatShell.querySelector('#activeChatReset');
+    const chatSendButton = chatShell.querySelector('.chat-send');
+    const statusIndicator = chatShell.querySelector('[data-chat-status-indicator]');
+    const statusText = chatShell.querySelector('[data-chat-status-text]');
+
+    if (!chatForm || !chatInput || !chatLog) {
+        return;
+    }
+
+    const conversation = [];
+    let isAwaitingReply = false;
+
+    const setStatus = (mode, message) => {
+        const config = statusStyles[mode];
+        if (!config) {
+            return;
+        }
+
+        if (statusIndicator) {
+            statusIndicator.style.background = config.color;
+            statusIndicator.style.boxShadow = config.glow;
+        }
+
+        if (statusText) {
+            statusText.textContent = message ?? config.label;
+        }
+    };
+
+    const addMessage = (role, text) => {
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('chat-message');
+
+        if (role === 'user') {
+            wrapper.classList.add('chat-message--user');
+        } else if (role === 'ally') {
+            wrapper.classList.add('chat-message--ally');
+        } else {
+            wrapper.classList.add('chat-message--system');
+        }
+
+        const author = document.createElement('span');
+        author.className = 'chat-author';
+        if (role === 'user') {
+            author.textContent = 'You';
+        } else if (role === 'ally') {
+            author.textContent = 'Operative Lynx';
+        } else {
+            author.textContent = 'System';
+        }
+
+        const messageBody = document.createElement('p');
+        messageBody.textContent = text;
+
+        const timeStamp = document.createElement('time');
+        const now = new Date();
+        timeStamp.setAttribute('datetime', now.toISOString());
+        timeStamp.textContent = formatTimestamp(now);
+
+        wrapper.append(author, messageBody, timeStamp);
+        chatLog.append(wrapper);
+        chatLog.scrollTo({ top: chatLog.scrollHeight, behavior: 'smooth' });
+    };
+
+    const trimHistory = () => {
+        while (conversation.length > HISTORY_LIMIT) {
+            conversation.shift();
+        }
+    };
+
+    const toggleInputState = (disabled) => {
+        chatInput.disabled = disabled;
+        if (chatSendButton) {
+            chatSendButton.disabled = disabled;
+            if (disabled) {
+                chatSendButton.setAttribute('aria-disabled', 'true');
+            } else {
+                chatSendButton.removeAttribute('aria-disabled');
+            }
+        }
+
+        if (!disabled) {
+            chatInput.focus();
+        }
+    };
+
+    const requestReply = async () => {
+        if (isAwaitingReply || conversation.length === 0) {
+            return;
+        }
+
+        isAwaitingReply = true;
+        setStatus('responding', 'Routing to Operative Lynx...');
+        toggleInputState(true);
+
+        try {
+            const response = await fetch('/api/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ history: conversation }),
+            });
+
+            let payload;
+            try {
+                payload = await response.json();
+            } catch (parseError) {
+                throw new Error('Unrecognized response from the relay.');
+            }
+
+            if (!response.ok) {
+                const message =
+                    typeof payload?.error === 'string'
+                        ? payload.error
+                        : `Transmission failed (status ${response.status}).`;
+                throw new Error(message);
+            }
+
+            const reply = typeof payload?.reply === 'string' ? payload.reply.trim() : '';
+
+            if (!reply) {
+                throw new Error('No reply text returned.');
+            }
+
+            addMessage('ally', reply);
+            conversation.push({ role: 'assistant', content: reply });
+            trimHistory();
+        } catch (error) {
+            console.error('Active chat error:', error);
+            const notice =
+                error instanceof Error && error.message
+                    ? error.message
+                    : 'Transmission jammed. Try resubmitting in a moment.';
+            addMessage('system', notice);
+        } finally {
+            isAwaitingReply = false;
+            setStatus('idle');
+            toggleInputState(false);
+        }
+    };
+
+    const resetChat = () => {
+        chatLog.innerHTML = '';
+        conversation.length = 0;
+        chatInput.value = '';
+        addMessage('system', 'Channel secured. Introduce yourself and drop the sharpest intel you have.');
+        const greeting =
+            'Operative Lynx online. Keep it concise and let me know what intel needs eyes.';
+        addMessage('ally', greeting);
+        conversation.push({ role: 'assistant', content: greeting });
+        setStatus('idle');
+        toggleInputState(false);
+        isAwaitingReply = false;
+    };
+
+    chatForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const message = chatInput.value.trim();
+        if (!message || isAwaitingReply) {
+            return;
+        }
+
+        addMessage('user', message);
+        conversation.push({ role: 'user', content: message });
+        trimHistory();
+        chatInput.value = '';
+        chatInput.focus();
+        await requestReply();
+    });
+
+    chatInput.addEventListener('focus', () => setStatus('listening', 'Monitoring input...'));
+    chatInput.addEventListener('blur', () => setStatus('idle'));
+
+    if (chatReset) {
+        chatReset.addEventListener('click', () => {
+            resetChat();
+        });
+    }
+
+    resetChat();
+};

--- a/public/assets/js/site.js
+++ b/public/assets/js/site.js
@@ -1,4 +1,5 @@
 import { startMatrixRain } from './matrix.js';
+import { initActiveChat } from './chat.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     startMatrixRain();
@@ -14,4 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
             link.classList.add('active');
         }
     });
+
+    if (document.querySelector('[data-chat-shell]')) {
+        initActiveChat();
+    }
 });

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/chat.css">
     <script type="module" src="/assets/js/site.js" defer></script>
     <script type="module" src="https://unpkg.com/lucide@latest" defer></script>
 </head>
@@ -40,6 +41,45 @@
                     <h3 class="font-mono" style="color: var(--color-neon-primary); letter-spacing: 0.1em;">Breach Archives</h3>
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem;">Learn from the past. We dissect major historical data breaches to understand their impact and prevention.</p>
                 </a>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="message-circle"></i> Active Chat: Memorable Intel Exchange</h2>
+            <p class="highlight">
+                Engage with the HackTech community through our active chat hub. Drop in memorable intel, share defensive tactics, and keep the conversation thriving with every text you enter.
+            </p>
+            <div class="chat-shell" data-chat-shell>
+                <div class="chat-window" id="activeChatLog" aria-live="polite"></div>
+                <noscript class="chat-noscript">
+                    Activate JavaScript to join the live intel exchange.
+                </noscript>
+                <div class="chat-meta">
+                    <div class="chat-status" aria-live="polite">
+                        <span class="chat-status-indicator" data-chat-status-indicator></span>
+                        <span data-chat-status-text>Standing by</span>
+                    </div>
+                    <button class="chat-clear" type="button" id="activeChatReset">
+                        <i data-lucide="rotate-ccw"></i>
+                        Reset Thread
+                    </button>
+                </div>
+                <form class="chat-entry" id="activeChatForm" autocomplete="off">
+                    <label class="chat-label" for="activeChatInput">Transmit a message</label>
+                    <div class="chat-controls">
+                        <input
+                            type="text"
+                            id="activeChatInput"
+                            name="message"
+                            placeholder="Type a field report..."
+                            required
+                            minlength="1"
+                        />
+                        <button type="submit" class="chat-send">
+                            <i data-lucide="send"></i>
+                            Send
+                        </button>
+                    </div>
+                </form>
             </div>
         </section>
         <footer>

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -1,0 +1,109 @@
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { onRequestPost } from '../functions/api/chat.js';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+    globalThis.fetch = async () =>
+        new Response(
+            JSON.stringify({
+                result: {
+                    response: 'Acknowledged. Holding the line.',
+                },
+            }),
+            { headers: { 'content-type': 'application/json' } }
+        );
+});
+
+after(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test('onRequestPost forwards conversation history to Cloudflare AI', async () => {
+    const fetchCalls = [];
+
+    globalThis.fetch = async (...args) => {
+        fetchCalls.push(args);
+        return new Response(
+            JSON.stringify({
+                result: {
+                    response: 'Intel received. Issuing countermeasure advice.',
+                },
+            }),
+            { headers: { 'content-type': 'application/json' } }
+        );
+    };
+
+    const request = new Request('https://example.com/api/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            history: [
+                { role: 'assistant', content: 'Operative Lynx ready.' },
+                { role: 'user', content: '  Need insight on phishing surge  ' },
+            ],
+        }),
+    });
+
+    const response = await onRequestPost({
+        env: {
+            CLOUDFLARE_ACCOUNT_ID: 'acct',
+            CLOUDFLARE_AI_TOKEN: 'token',
+        },
+        request,
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.clone().json();
+    assert.equal(payload.reply, 'Intel received. Issuing countermeasure advice.');
+
+    assert.equal(fetchCalls.length, 1, 'Cloudflare AI should be called once');
+    const [, options] = fetchCalls[0];
+    assert.equal(options.method, 'POST');
+    const parsedBody = JSON.parse(options.body);
+    assert.equal(parsedBody.messages[0].role, 'system');
+    assert.match(parsedBody.messages[0].content, /Operative Lynx/);
+    assert.deepEqual(parsedBody.messages.slice(1), [
+        { role: 'assistant', content: 'Operative Lynx ready.' },
+        { role: 'user', content: 'Need insight on phishing surge' },
+    ]);
+});
+
+test('onRequestPost fails when AI credentials are missing', async () => {
+    const request = new Request('https://example.com/api/chat', {
+        method: 'POST',
+        body: JSON.stringify({
+            history: [{ role: 'assistant', content: 'hello' }],
+        }),
+    });
+
+    const response = await onRequestPost({
+        env: {},
+        request,
+    });
+
+    assert.equal(response.status, 500);
+    const payload = await response.clone().json();
+    assert.match(payload.error, /not configured/i);
+});
+
+test('onRequestPost rejects empty conversation history', async () => {
+    const request = new Request('https://example.com/api/chat', {
+        method: 'POST',
+        body: JSON.stringify({ history: [] }),
+    });
+
+    const response = await onRequestPost({
+        env: {
+            CLOUDFLARE_ACCOUNT_ID: 'acct',
+            CLOUDFLARE_AI_TOKEN: 'token',
+        },
+        request,
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.clone().json();
+    assert.match(payload.error, /history is required/i);
+});


### PR DESCRIPTION
## Summary
- replace the simulated active chat logic with a Cloudflare AI-backed request flow, including history management and error surfacing in the UI
- add a secure Worker endpoint that relays chat history to Cloudflare AI using configured credentials and limits payload size
- update chat control styles for disabled states and cover the new endpoint with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd2495ea148327a029b2508f7baf03