### PR TITLE
Add Midjourney command deck page

### DIFF
--- a/public/arsenal.html
+++ b/public/arsenal.html
@@ -22,6 +22,7 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -229,6 +229,62 @@ nav {
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.midjourney-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.25fr);
+    gap: 1.75rem;
+    align-items: stretch;
+    margin-top: 1.5rem;
+}
+
+.midjourney-instructions {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.midjourney-steps {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.85rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.92rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.midjourney-steps li::marker {
+    color: var(--color-neon-primary);
+}
+
+.midjourney-frame {
+    border: 1px solid rgba(0, 255, 136, 0.3);
+    border-radius: 1rem;
+    background: rgba(0, 8, 4, 0.6);
+    box-shadow: 0 0 20px rgba(0, 255, 136, 0.18);
+    min-height: 30rem;
+    overflow: hidden;
+}
+
+.midjourney-frame iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 1rem;
+    background: #050505;
+}
+
+.midjourney-note {
+    margin: 0;
+    padding: 1rem 1.1rem;
+    border-radius: 0.75rem;
+    border: 1px dashed rgba(0, 255, 136, 0.35);
+    background: rgba(0, 15, 8, 0.35);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    color: rgba(204, 255, 204, 0.85);
+}
+
 footer {
     margin-top: 4rem;
     padding-top: 1.5rem;
@@ -356,6 +412,16 @@ button:hover {
 
     .site-subtitle {
         letter-spacing: 0.35em;
+    }
+}
+
+@media (max-width: 980px) {
+    .midjourney-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .midjourney-frame {
+        min-height: 26rem;
     }
 }
 

--- a/public/breach-archives.html
+++ b/public/breach-archives.html
@@ -22,6 +22,7 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>

--- a/public/daily-briefing.html
+++ b/public/daily-briefing.html
@@ -23,6 +23,7 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>

--- a/public/midjourney.html
+++ b/public/midjourney.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contact | HackTech</title>
+    <title>HackTech Midjourney Ops</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
@@ -11,7 +11,7 @@
     <script type="module" src="/assets/js/site.js" defer></script>
     <script type="module" src="https://unpkg.com/lucide@latest" defer></script>
 </head>
-<body data-page="contact">
+<body data-page="midjourney">
     <canvas id="matrixCanvas" class="matrix-canvas"></canvas>
     <div class="scanline-overlay"></div>
     <main class="container">
@@ -28,30 +28,41 @@
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>
         </nav>
         <section class="cyber-panel">
-            <h2><i data-lucide="mail"></i> Secure Contact</h2>
+            <h2><i data-lucide="sparkles"></i> Midjourney Command Deck</h2>
             <p class="highlight">
-                Have questions or want to report a security concern? Use the form below. All communications should be for educational purposes only.
+                HackTech now ships with the Lobe Midjourney Web UI so operators can craft visual intelligence directly from the command deck.
+                Configure your Midjourney proxy once and orchestrate prompts, upscale jobs, and review image generations without leaving the grid.
             </p>
-            <div class="data-card" style="margin-bottom: 2rem;">
-                <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.85rem; line-height: 1.7;">
-                    <strong class="text-strong">Form integration tip:</strong> Create a free account at <a href="https://formspree.io/" target="_blank" rel="noopener noreferrer" style="color: var(--color-neon-primary);">Formspree</a> and copy your unique endpoint. Replace <code>YOUR_UNIQUE_FORMSPREE_ENDPOINT</code> in the form action below with that value to receive submissions directly in your inbox.
-                </p>
+            <div class="resource-actions">
+                <a class="resource-link" href="https://github.com/lobehub/lobe-midjourney-webui" target="_blank" rel="noopener noreferrer">
+                    <i data-lucide="github"></i>
+                    Lobe Midjourney Web UI
+                </a>
+                <a class="resource-link" href="https://github.com/novicezk/midjourney-proxy" target="_blank" rel="noopener noreferrer">
+                    <i data-lucide="external-link"></i>
+                    Midjourney Proxy
+                </a>
+                <a class="resource-link" href="https://midjourney-webui.lobehub.com" target="_blank" rel="noopener noreferrer">
+                    <i data-lucide="globe"></i>
+                    Hosted Demo
+                </a>
             </div>
-            <form action="https://formspree.io/f/YOUR_UNIQUE_FORMSPREE_ENDPOINT" method="POST">
-                <div>
-                    <label for="handle">HANDLE / ALIAS</label>
-                    <input type="text" id="handle" name="handle" placeholder="Security_Researcher_01" required>
+            <div class="midjourney-layout">
+                <div class="midjourney-instructions">
+                    <span class="highlight-heading">Deploy &amp; Connect</span>
+                    <ol class="midjourney-steps">
+                        <li>Launch the <code>midjourney-proxy</code> service (Docker makes it a one-command deploy) and populate <code>application.yml</code> with your Discord guild, channel, and token credentials.</li>
+                        <li>Expose the proxy endpoint (for example, <code>https://your-proxy.example.com</code>) and confirm <code>/mj</code> responds with the available APIs.</li>
+                        <li>Open the settings panel inside the Midjourney deck, paste the proxy URL, and authenticate. The UI immediately syncs queued jobs and prompt presets.</li>
+                    </ol>
+                    <p class="midjourney-note">
+                        Need the full runbook? Follow the official setup guide bundled with the Lobe Midjourney Web UI repository for port mappings, optional task stores, and advanced tuning tips.
+                    </p>
                 </div>
-                <div>
-                    <label for="reply_to">YOUR CONTACT EMAIL</label>
-                    <input type="email" id="reply_to" name="reply_to" placeholder="Your Contact Email (Optional)">
+                <div class="midjourney-frame">
+                    <iframe src="https://midjourney.chat-plugin.lobehub.com/iframe" title="Lobe Midjourney Web UI" loading="lazy" allow="clipboard-write"></iframe>
                 </div>
-                <div>
-                    <label for="message">MESSAGE</label>
-                    <textarea id="message" name="message" rows="5" placeholder="Enter your message here..." required></textarea>
-                </div>
-                <button type="submit">Transmit Data Packet</button>
-            </form>
+            </div>
         </section>
         <footer>
             <div class="socials">


### PR DESCRIPTION
## Summary
- add a Midjourney command deck page that embeds the Lobe Midjourney Web UI and outlines setup steps
- extend the global navigation to include the new page across the static site
- introduce responsive styling for the Midjourney layout and iframe container

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd5d3a58988327adcb8055bcbe0e8b