### PR TITLE
Add analyst chat console to daily briefing page

### DIFF
--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -1,0 +1,124 @@
+export async function onRequestPost(context) {
+    const { env, request } = context;
+
+    if (request.method !== 'POST') {
+        return new Response('Method Not Allowed', { status: 405, headers: { Allow: 'POST' } });
+    }
+
+    const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+    const apiToken = env.CLOUDFLARE_AI_TOKEN;
+
+    if (!accountId || !apiToken) {
+        return new Response(
+            JSON.stringify({ error: 'Cloudflare AI environment variables are not configured.' }),
+            {
+                status: 500,
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+    }
+
+    let body;
+    try {
+        body = await request.json();
+    } catch (error) {
+        return new Response(JSON.stringify({ error: 'Invalid JSON payload.' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    const rawMessages = Array.isArray(body?.messages) ? body.messages : [];
+    if (rawMessages.length === 0) {
+        return new Response(JSON.stringify({ error: 'At least one message is required.' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    const allowedRoles = new Set(['user', 'assistant']);
+    const chatHistory = [];
+
+    for (const message of rawMessages) {
+        if (!message || typeof message !== 'object') {
+            continue;
+        }
+
+        const role = typeof message.role === 'string' ? message.role.toLowerCase() : 'user';
+        const content = typeof message.content === 'string' ? message.content.trim() : '';
+
+        if (!content) {
+            continue;
+        }
+
+        if (allowedRoles.has(role)) {
+            chatHistory.push({ role, content });
+        }
+    }
+
+    if (chatHistory.length === 0) {
+        return new Response(JSON.stringify({ error: 'No valid chat messages provided.' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    const systemPrompt = [
+        'You are the on-call HackTech cyber intelligence analyst embedded in a defensive operations team.',
+        'Respond with precise, actionable insight rooted in cybersecurity best practices.',
+        'Reference known frameworks (MITRE ATT&CK, NIST, CIS) when useful and keep answers under 220 words unless additional detail is requested.',
+        'Use paragraphs or concise lists rather than markdown headings.',
+    ].join(' ');
+
+    const messages = [
+        { role: 'system', content: systemPrompt },
+        ...chatHistory.slice(-12),
+    ];
+
+    try {
+        const aiResponse = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/@cf/meta/llama-3-8b-instruct`,
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${apiToken}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ messages }),
+            }
+        );
+
+        if (!aiResponse.ok) {
+            const errorText = await aiResponse.text();
+            throw new Error(`Cloudflare AI error: ${aiResponse.status} ${aiResponse.statusText} - ${errorText}`);
+        }
+
+        const result = await aiResponse.json();
+        const aiText =
+            result?.result?.response ??
+            result?.result?.output_text ??
+            result?.result?.text ??
+            result?.result ??
+            null;
+
+        if (!aiText || typeof aiText !== 'string') {
+            throw new Error('Unexpected response from Cloudflare AI');
+        }
+
+        return new Response(
+            JSON.stringify({ reply: aiText.trim(), createdAt: new Date().toISOString() }),
+            {
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+    } catch (error) {
+        console.error('Analyst chat function error:', error);
+        return new Response(
+            JSON.stringify({ error: 'Unable to retrieve analyst response.' }),
+            {
+                status: 500,
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+    }
+}

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -200,6 +200,134 @@ nav {
     animation-delay: -0.16s;
 }
 
+.briefing-layout {
+    display: grid;
+    gap: 1.75rem;
+    margin-top: 2rem;
+}
+
+.chat-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.chat-thread {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.25rem;
+    border: 1px solid rgba(0, 255, 136, 0.25);
+    border-radius: 0.9rem;
+    background: rgba(0, 8, 4, 0.35);
+    box-shadow: inset 0 0 12px rgba(0, 255, 136, 0.08);
+    min-height: 18rem;
+    max-height: 32rem;
+    overflow-y: auto;
+    scroll-behavior: smooth;
+}
+
+.chat-message {
+    display: grid;
+    gap: 0.35rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.9rem;
+}
+
+.chat-message header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+}
+
+.chat-message[data-role='assistant'] header {
+    color: var(--color-neon-primary);
+}
+
+.chat-message[data-role='user'] header {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.chat-bubble {
+    padding: 0.85rem 1rem;
+    border-radius: 0.8rem;
+    border: 1px solid rgba(0, 255, 136, 0.2);
+    background: rgba(0, 0, 0, 0.35);
+    line-height: 1.55;
+    white-space: pre-wrap;
+}
+
+.chat-message[data-role='user'] .chat-bubble {
+    border-color: rgba(94, 234, 212, 0.4);
+    background: rgba(15, 118, 110, 0.25);
+}
+
+.chat-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.chat-status .loading-dots {
+    margin-left: 0.25rem;
+}
+
+.chat-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.chat-input {
+    resize: vertical;
+    min-height: 6rem;
+    max-height: 16rem;
+}
+
+.chat-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    justify-content: space-between;
+}
+
+.chat-hint {
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.5);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.chat-send {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.35rem;
+}
+
+.chat-send[disabled] {
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 @keyframes dot-pulse {
     0%, 80%, 100% {
         transform: scale(0);
@@ -412,6 +540,13 @@ button:hover {
 
     .site-subtitle {
         letter-spacing: 0.35em;
+    }
+}
+
+@media (min-width: 1024px) {
+    .briefing-layout {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        align-items: start;
     }
 }
 

--- a/public/assets/js/chat.js
+++ b/public/assets/js/chat.js
@@ -1,0 +1,174 @@
+const systemMessage = {
+    role: 'system',
+    content:
+        'You are a world-class cybersecurity analyst assisting the HackTech Daily Briefing audience. Provide concise, technically accurate insights and suggest next steps when helpful.',
+};
+
+const conversation = [systemMessage];
+
+function getElements() {
+    return {
+        thread: document.getElementById('chat-thread'),
+        form: document.getElementById('chat-form'),
+        input: document.getElementById('chat-input'),
+        sendButton: document.querySelector('[data-chat-send]'),
+        wrapper: document.querySelector('[data-chat-wrapper]'),
+    };
+}
+
+function appendMessage(role, content) {
+    const { thread } = getElements();
+    if (!thread) return null;
+
+    const message = document.createElement('div');
+    message.className = 'chat-message';
+    message.dataset.role = role;
+
+    const header = document.createElement('header');
+    header.textContent = role === 'user' ? 'Operative' : 'Analyst';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'chat-bubble';
+    bubble.textContent = content;
+
+    message.appendChild(header);
+    message.appendChild(bubble);
+    thread.appendChild(message);
+    thread.scrollTop = thread.scrollHeight;
+    return message;
+}
+
+function createTypingIndicator() {
+    const indicator = document.createElement('div');
+    indicator.className = 'chat-message';
+    indicator.dataset.role = 'assistant';
+    indicator.dataset.state = 'typing';
+
+    const header = document.createElement('header');
+    header.textContent = 'Analyst';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'chat-bubble';
+
+    const status = document.createElement('span');
+    status.className = 'chat-status';
+    status.textContent = 'Synthesizing intel';
+
+    const dots = document.createElement('span');
+    dots.className = 'loading-dots';
+    dots.innerHTML = '<span></span><span></span><span></span>';
+
+    status.appendChild(dots);
+    bubble.appendChild(status);
+
+    indicator.appendChild(header);
+    indicator.appendChild(bubble);
+    return indicator;
+}
+
+function setBusyState(isBusy) {
+    const { sendButton, wrapper, thread } = getElements();
+    if (sendButton) {
+        sendButton.disabled = isBusy;
+    }
+    if (wrapper) {
+        wrapper.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+    }
+    if (thread) {
+        thread.setAttribute('aria-busy', isBusy ? 'true' : 'false');
+    }
+}
+
+async function transmitMessage(event) {
+    event.preventDefault();
+    const { input, thread } = getElements();
+    if (!input || !thread) {
+        return;
+    }
+
+    const userMessage = input.value.trim();
+    if (!userMessage) {
+        return;
+    }
+
+    appendMessage('user', userMessage);
+    conversation.push({ role: 'user', content: userMessage });
+    input.value = '';
+    input.style.height = '';
+
+    const typingIndicator = createTypingIndicator();
+    thread.appendChild(typingIndicator);
+    thread.scrollTop = thread.scrollHeight;
+
+    setBusyState(true);
+
+    try {
+        const response = await fetch('/api/chat', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ messages: conversation }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Chat API error: ${response.status}`);
+        }
+
+        const payload = await response.json();
+        const reply = (payload?.reply ?? payload?.result ?? '').toString().trim();
+
+        if (!reply) {
+            throw new Error('Empty response from analyst');
+        }
+
+        conversation.push({ role: 'assistant', content: reply });
+        typingIndicator.remove();
+        appendMessage('assistant', reply);
+    } catch (error) {
+        console.error('Chat console error:', error);
+        typingIndicator.remove();
+        appendMessage(
+            'assistant',
+            'Signal lost while contacting the analyst. Check your connection and try again.'
+        );
+    } finally {
+        setBusyState(false);
+    }
+}
+
+function autoResize(event) {
+    const field = event.target;
+    if (!(field instanceof HTMLTextAreaElement)) {
+        return;
+    }
+    field.style.height = 'auto';
+    field.style.height = `${Math.min(field.scrollHeight, 320)}px`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const { form, input } = getElements();
+    if (!form || !input) {
+        return;
+    }
+
+    appendMessage(
+        'assistant',
+        'Welcome back, operative. I can expand on any briefing item, analyze potential impact, or suggest mitigation steps. What intel do you need?'
+    );
+    conversation.push({
+        role: 'assistant',
+        content:
+            'Welcome back, operative. I can expand on any briefing item, analyze potential impact, or suggest mitigation steps. What intel do you need?',
+    });
+
+    form.addEventListener('submit', transmitMessage);
+    input.addEventListener('input', autoResize);
+
+    input.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            form.requestSubmit();
+        }
+    });
+});

--- a/public/daily-briefing.html
+++ b/public/daily-briefing.html
@@ -11,6 +11,7 @@
     <script type="module" src="/assets/js/site.js" defer></script>
     <script type="module" src="https://unpkg.com/lucide@latest" defer></script>
     <script src="/assets/js/briefing.js" defer></script>
+    <script src="/assets/js/chat.js" defer></script>
 </head>
 <body data-page="daily">
     <canvas id="matrixCanvas" class="matrix-canvas"></canvas>
@@ -28,17 +29,37 @@
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>
         </nav>
-        <section class="cyber-panel">
-            <h2><i data-lucide="shield-check"></i> AI-Powered Daily Briefing</h2>
-            <div id="briefing-content" class="font-mono" style="text-align: center;">
-                <p>Fetching latest intel from the grid...</p>
-                <div class="loading-dots" style="justify-content: center; margin-top: 1.5rem;">
-                    <span></span>
-                    <span></span>
-                    <span></span>
+        <div class="briefing-layout">
+            <section class="cyber-panel" aria-labelledby="daily-briefing-heading">
+                <h2 id="daily-briefing-heading"><i data-lucide="shield-check"></i> AI-Powered Daily Briefing</h2>
+                <div id="briefing-content" class="font-mono" style="text-align: center;">
+                    <p>Fetching latest intel from the grid...</p>
+                    <div class="loading-dots" style="justify-content: center; margin-top: 1.5rem;">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </div>
                 </div>
-            </div>
-        </section>
+            </section>
+
+            <section class="cyber-panel" id="analyst-chat" aria-labelledby="analyst-chat-heading">
+                <h2 id="analyst-chat-heading"><i data-lucide="messages-square"></i> Analyst Chat Console</h2>
+                <div class="chat-wrapper" data-chat-wrapper>
+                    <div class="chat-thread" id="chat-thread" aria-live="polite" aria-busy="false"></div>
+                    <form id="chat-form" class="chat-form" autocomplete="off">
+                        <label class="sr-only" for="chat-input">Send a message to the HackTech analyst</label>
+                        <textarea id="chat-input" class="chat-input font-mono" name="message" rows="3" placeholder="Ask the analyst to expand on any threat, mitigation, or tooling..." required></textarea>
+                        <div class="chat-actions">
+                            <span class="chat-hint font-mono">Shift + Enter for new line</span>
+                            <button type="submit" class="chat-send" data-chat-send>
+                                <span>Transmit</span>
+                                <i data-lucide="send"></i>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </section>
+        </div>
         <footer>
             <div class="socials">
                 <a href="https://facebook.com/YOUR_PAGE_HERE" target="_blank" rel="noopener noreferrer" aria-label="Facebook">

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -1,0 +1,107 @@
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { onRequestPost } from '../functions/api/chat.js';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+    globalThis.fetch = async () =>
+        new Response(
+            JSON.stringify({
+                result: {
+                    response: 'Sample analyst insight',
+                },
+            }),
+            {
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+});
+
+after(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test('onRequestPost forwards chat history and returns analyst reply', async () => {
+    const requests = [];
+    globalThis.fetch = async (input, init) => {
+        requests.push({ input, init });
+        return new Response(
+            JSON.stringify({
+                result: {
+                    response: 'Actionable response',
+                },
+            }),
+            {
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+    };
+
+    const request = new Request('https://example.com/api/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            messages: [
+                { role: 'user', content: 'Need mitigation advice.' },
+                { role: 'assistant', content: 'Previous answer.' },
+            ],
+        }),
+    });
+
+    const response = await onRequestPost({
+        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
+        request,
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.clone().json();
+    assert.equal(payload.reply, 'Actionable response');
+
+    assert.equal(requests.length, 1);
+    const forwarded = JSON.parse(requests[0].init.body);
+    assert.equal(forwarded.messages[0].role, 'system');
+    assert.equal(forwarded.messages[1].role, 'user');
+    assert.equal(forwarded.messages[2].role, 'assistant');
+});
+
+test('onRequestPost rejects invalid payloads', async () => {
+    const request = new Request('https://example.com/api/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ notMessages: true }),
+    });
+
+    const response = await onRequestPost({
+        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
+        request,
+    });
+
+    assert.equal(response.status, 400);
+    const payload = await response.clone().json();
+    assert.match(payload.error, /message/i);
+});
+
+test('onRequestPost fails when credentials are missing', async () => {
+    const request = new Request('https://example.com/api/chat', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'Ping' }] }),
+    });
+
+    const response = await onRequestPost({ env: {}, request });
+
+    assert.equal(response.status, 500);
+    const payload = await response.clone().json();
+    assert.match(payload.error, /not configured/i);
+});
+
+test('onRequestPost rejects unsupported methods', async () => {
+    const response = await onRequestPost({
+        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
+        request: new Request('https://example.com/api/chat', { method: 'GET' }),
+    });
+
+    assert.equal(response.status, 405);
+});


### PR DESCRIPTION
## Summary
- add an analyst chat console to the daily briefing page with responsive styling and interactions
- proxy chat messages through a new Cloudflare Pages Function that calls Workers AI
- cover the new API behaviour with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd6068f8c483279924f505aa3aa6e5