### PR TITLE
Sanitize daily briefing markdown rendering

### DIFF
--- a/public/assets/js/briefing.js
+++ b/public/assets/js/briefing.js
@@ -19,11 +19,29 @@ async function fetchDailyBriefing() {
     }
 }
 
+function escapeHtml(value) {
+    if (value == null) {
+        return '';
+    }
+
+    const escapeMap = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+    };
+
+    return String(value).replace(/[&<>"']/g, (char) => escapeMap[char]);
+}
+
 function renderBriefing(rawText, generatedAt) {
     const container = document.getElementById('briefing-content');
     if (!container) return;
 
-    const htmlContent = rawText
+    const escapedText = escapeHtml(rawText);
+
+    const htmlContent = escapedText
         .replace(/### (.*)/g, '<span class="highlight-heading font-mono">&gt;&gt; $1</span>')
         .replace(/\*\*([^*]+)\*\*/g, '<strong class="text-strong">$1</strong>')
         .replace(/\* ([^*]+)/g, '<p class="briefing-paragraph">$1</p>')


### PR DESCRIPTION
## Summary
- add an HTML escaping helper before formatting daily briefing markdown
- render the sanitized content through the existing formatting wrappers to block injected HTML

## Testing
- npm test
- manual validation of daily-briefing page rendering legitimate markdown and displaying script tags as text

------
https://chatgpt.com/codex/tasks/task_e_68dd73d9d2248327a21eebbdaff3b129