### PR TITLE
Add Midjourney proxy support and status UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ functions/
    cat <<'EOF' > .dev.vars
    CLOUDFLARE_ACCOUNT_ID=e8823131dce5e3dcaedec59bb4f7c093
    CLOUDFLARE_AI_TOKEN=YOUR_TEMP_DEVELOPMENT_TOKEN
+   MIDJOURNEY_PROXY_URL=https://your-midjourney-proxy.example.com
    EOF
    ```
    Replace `YOUR_TEMP_DEVELOPMENT_TOKEN` with a valid API token. The token is read only by Wrangler during local development and should **not** be committed to git.
@@ -44,6 +45,7 @@ functions/
 3. In the Pages project settings, add the following environment variables under **Functions → Environment variables**:
    - `CLOUDFLARE_ACCOUNT_ID` → `e8823131dce5e3dcaedec59bb4f7c093`
    - `CLOUDFLARE_AI_TOKEN` → (create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the **AI** scope and paste it here)
+   - `MIDJOURNEY_PROXY_URL` → URL of your deployed [midjourney-proxy](https://github.com/novicezk/midjourney-proxy) instance (for example, `https://your-midjourney-proxy.example.com`)
 4. Trigger a deploy. Cloudflare will publish every file inside `public` and execute `functions/api/briefing.js` for `/api/briefing` requests.
 5. If you prefer deploying from the CLI, run:
    ```bash
@@ -55,6 +57,7 @@ functions/
 ## Updating integrations
 
 - **Daily Briefing**: The front end calls `/api/briefing`, which in turn invokes Cloudflare's `@cf/meta/llama-3-8b-instruct` model. Adjust the prompt in `functions/api/briefing.js` or point it at a different [Cloudflare AI model](https://developers.cloudflare.com/workers-ai/models/) by changing the endpoint path.
+- **Midjourney deck**: Configure `MIDJOURNEY_PROXY_URL` to point at your Midjourney proxy. Pages Functions expose `/api/midjourney/*` as a CORS-enabled pass-through so the embedded Lobe Midjourney UI can route imagine/upscale calls securely. Hit `/api/midjourney/status` to confirm the proxy is reachable—responses include a summarized payload from `/mj`.
 - **Contact form**: Replace `YOUR_UNIQUE_FORMSPREE_ENDPOINT` in `public/contact.html` with the endpoint provided by Formspree (or swap in your preferred provider).
 
 ## Notes

--- a/functions/api/midjourney/[...path].js
+++ b/functions/api/midjourney/[...path].js
@@ -1,0 +1,5 @@
+import { proxyToMidjourney } from '../../../lib/midjourney-proxy.js';
+
+export async function onRequest(context) {
+    return proxyToMidjourney(context, context.params?.path);
+}

--- a/functions/api/midjourney/index.js
+++ b/functions/api/midjourney/index.js
@@ -1,0 +1,5 @@
+import { proxyToMidjourney } from '../../../lib/midjourney-proxy.js';
+
+export async function onRequest(context) {
+    return proxyToMidjourney(context);
+}

--- a/functions/api/midjourney/status.js
+++ b/functions/api/midjourney/status.js
@@ -1,0 +1,5 @@
+import { midjourneyStatus } from '../../../lib/midjourney-proxy.js';
+
+export async function onRequest(context) {
+    return midjourneyStatus(context);
+}

--- a/lib/midjourney-proxy.js
+++ b/lib/midjourney-proxy.js
@@ -1,0 +1,189 @@
+const ALLOWED_PROXY_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+
+const CORS_HEADERS = {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'access-control-allow-headers': 'content-type, authorization',
+    'vary': 'origin',
+};
+
+function applyCorsHeaders(headers = new Headers()) {
+    const result = new Headers(headers);
+    for (const [key, value] of Object.entries(CORS_HEADERS)) {
+        if (key.toLowerCase() === 'vary') {
+            const existing = result.get('vary');
+            const varyValues = new Set();
+            if (existing) {
+                existing
+                    .split(',')
+                    .map((entry) => entry.trim())
+                    .filter(Boolean)
+                    .forEach((entry) => varyValues.add(entry));
+            }
+
+            value
+                .split(',')
+                .map((entry) => entry.trim())
+                .filter(Boolean)
+                .forEach((entry) => varyValues.add(entry));
+
+            result.set('vary', Array.from(varyValues).join(', ') || value);
+            continue;
+        }
+
+        result.set(key, value);
+    }
+    return result;
+}
+
+function createJsonResponse(payload, { status = 200, headers } = {}) {
+    const responseHeaders = applyCorsHeaders(headers);
+    responseHeaders.set('content-type', 'application/json');
+    return new Response(JSON.stringify(payload), { status, headers: responseHeaders });
+}
+
+function normalisePathSegments(pathSegments) {
+    if (!pathSegments) {
+        return '';
+    }
+
+    if (Array.isArray(pathSegments)) {
+        return pathSegments.filter((segment) => typeof segment === 'string' && segment.length > 0).join('/');
+    }
+
+    return typeof pathSegments === 'string' ? pathSegments.replace(/^\//, '') : '';
+}
+
+function validateAndResolveBaseUrl(rawUrl) {
+    if (!rawUrl) {
+        return { error: 'MIDJOURNEY_PROXY_URL environment variable is not configured.' };
+    }
+
+    try {
+        const url = new URL(rawUrl);
+        if (!url.pathname.endsWith('/')) {
+            url.pathname = `${url.pathname}/`;
+        }
+        return { url };
+    } catch (error) {
+        return { error: 'MIDJOURNEY_PROXY_URL must be a valid absolute URL.' };
+    }
+}
+
+export async function proxyToMidjourney(context, pathSegments) {
+    const { request, env } = context;
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers: applyCorsHeaders() });
+    }
+
+    if (!ALLOWED_PROXY_METHODS.includes(request.method)) {
+        return createJsonResponse(
+            { error: `Unsupported method: ${request.method}.` },
+            { status: 405, headers: new Headers({ Allow: ALLOWED_PROXY_METHODS.join(', ') }) }
+        );
+    }
+
+    const { url: baseUrl, error } = validateAndResolveBaseUrl(env.MIDJOURNEY_PROXY_URL);
+    if (error) {
+        return createJsonResponse({ error }, { status: 500 });
+    }
+
+    const suffix = normalisePathSegments(pathSegments);
+    const incomingUrl = new URL(request.url);
+    const targetUrl = new URL(suffix, baseUrl);
+    targetUrl.search = incomingUrl.search;
+
+    const headers = new Headers(request.headers);
+    headers.delete('host');
+    headers.delete('content-length');
+    headers.set('origin', baseUrl.origin);
+
+    let body;
+    if (!['GET', 'HEAD'].includes(request.method)) {
+        const buffer = await request.arrayBuffer();
+        body = buffer.byteLength > 0 ? buffer : null;
+    }
+
+    try {
+        const upstreamResponse = await fetch(targetUrl.toString(), {
+            method: request.method,
+            headers,
+            body: body ?? undefined,
+        });
+
+        const responseHeaders = applyCorsHeaders(upstreamResponse.headers);
+        return new Response(upstreamResponse.body, {
+            status: upstreamResponse.status,
+            headers: responseHeaders,
+        });
+    } catch (err) {
+        console.error('Midjourney proxy request failed:', err);
+        return createJsonResponse(
+            { error: 'Failed to reach the configured Midjourney proxy.' },
+            { status: 502 }
+        );
+    }
+}
+
+export async function midjourneyStatus(context) {
+    const { request, env } = context;
+
+    if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers: applyCorsHeaders() });
+    }
+
+    if (request.method !== 'GET') {
+        return createJsonResponse(
+            { error: 'Method not allowed. Use GET for status checks.' },
+            { status: 405, headers: new Headers({ Allow: 'GET, OPTIONS' }) }
+        );
+    }
+
+    const { url: baseUrl, error } = validateAndResolveBaseUrl(env.MIDJOURNEY_PROXY_URL);
+    if (error) {
+        return createJsonResponse({ ok: false, error }, { status: 500 });
+    }
+
+    const statusUrl = new URL('mj', baseUrl);
+
+    try {
+        const upstreamResponse = await fetch(statusUrl.toString(), {
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+        });
+
+        const summary = {
+            ok: upstreamResponse.ok,
+            upstreamStatus: upstreamResponse.status,
+        };
+
+        if (upstreamResponse.ok) {
+            try {
+                summary.upstream = await upstreamResponse.clone().json();
+            } catch {
+                const message = (await upstreamResponse.text()).trim();
+                if (message) {
+                    summary.message = message.slice(0, 5000);
+                }
+            }
+
+            if (!summary.message) {
+                summary.message = 'Midjourney proxy responded successfully.';
+            }
+        } else {
+            const errorText = (await upstreamResponse.text()).trim();
+            if (errorText) {
+                summary.error = errorText.slice(0, 5000);
+            }
+        }
+
+        return createJsonResponse(summary, { status: upstreamResponse.ok ? 200 : 502 });
+    } catch (err) {
+        console.error('Midjourney status check failed:', err);
+        return createJsonResponse(
+            { ok: false, error: 'Unable to contact the Midjourney proxy for status.' },
+            { status: 502 }
+        );
+    }
+}

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -385,6 +385,121 @@ nav {
     color: var(--color-neon-primary);
 }
 
+.midjourney-status {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    border: 1px solid rgba(0, 255, 136, 0.4);
+    border-radius: 0.85rem;
+    background: rgba(0, 12, 6, 0.55);
+    box-shadow: 0 0 18px rgba(0, 255, 136, 0.18);
+    font-family: 'Roboto Mono', monospace;
+}
+
+.midjourney-status-indicator {
+    width: 0.9rem;
+    height: 0.9rem;
+    border-radius: 50%;
+    border: 2px solid rgba(0, 255, 136, 0.6);
+    background: radial-gradient(circle, rgba(0, 255, 136, 0.9) 0%, rgba(0, 255, 136, 0.35) 70%, transparent 100%);
+    box-shadow: 0 0 12px rgba(0, 255, 136, 0.7);
+    transition: background 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.midjourney-status-text {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(224, 255, 235, 0.9);
+}
+
+.midjourney-status-details {
+    margin: 0.75rem 0 0;
+    padding: 0.75rem;
+    border-radius: 0.6rem;
+    border: 1px dashed rgba(0, 255, 136, 0.25);
+    background: rgba(0, 0, 0, 0.25);
+    font-size: 0.75rem;
+    color: rgba(191, 255, 214, 0.85);
+    max-height: 12rem;
+    overflow: auto;
+}
+
+.midjourney-status-body {
+    display: flex;
+    flex-direction: column;
+}
+
+.midjourney-status-refresh {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.55rem 0.9rem;
+    border: 1px solid rgba(0, 255, 136, 0.55);
+    border-radius: 0.6rem;
+    background: rgba(0, 0, 0, 0.35);
+    color: rgba(224, 255, 235, 0.95);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
+}
+
+.midjourney-status-refresh:hover {
+    background: rgba(0, 255, 136, 0.2);
+    box-shadow: 0 0 12px rgba(0, 255, 136, 0.35);
+    transform: translateY(-1px);
+}
+
+.midjourney-status[data-state='loading'] .midjourney-status-indicator {
+    animation: statusPulse 1.2s ease-in-out infinite;
+}
+
+.midjourney-status[data-state='connected'] .midjourney-status-indicator {
+    border-color: rgba(0, 255, 136, 0.8);
+    background: radial-gradient(circle, rgba(0, 255, 136, 1) 0%, rgba(0, 255, 136, 0.45) 70%, transparent 100%);
+    box-shadow: 0 0 14px rgba(0, 255, 136, 0.8);
+}
+
+.midjourney-status[data-state='error'] .midjourney-status-indicator {
+    border-color: rgba(255, 0, 82, 0.8);
+    background: radial-gradient(circle, rgba(255, 45, 102, 0.95) 0%, rgba(255, 45, 102, 0.4) 70%, transparent 100%);
+    box-shadow: 0 0 14px rgba(255, 45, 102, 0.75);
+}
+
+.midjourney-status[data-state='error'] .midjourney-status-text {
+    color: rgba(255, 190, 210, 0.95);
+}
+
+.midjourney-status[data-state='error'] .midjourney-status-refresh {
+    border-color: rgba(255, 0, 82, 0.55);
+}
+
+.midjourney-status[data-state='error'] .midjourney-status-refresh:hover {
+    box-shadow: 0 0 12px rgba(255, 0, 82, 0.35);
+}
+
+.midjourney-status[data-state='loading'] .midjourney-status-text {
+    color: rgba(224, 255, 235, 0.75);
+}
+
+.midjourney-status[data-state='loading'] .midjourney-status-refresh {
+    opacity: 0.7;
+}
+
+@keyframes statusPulse {
+    0%,
+    100% {
+        box-shadow: 0 0 10px rgba(0, 255, 136, 0.3);
+    }
+    50% {
+        box-shadow: 0 0 14px rgba(0, 255, 136, 0.65);
+    }
+}
+
 .midjourney-frame {
     border: 1px solid rgba(0, 255, 136, 0.3);
     border-radius: 1rem;
@@ -557,6 +672,15 @@ button:hover {
 
     .midjourney-frame {
         min-height: 26rem;
+    }
+
+    .midjourney-status {
+        grid-template-columns: 1fr;
+        text-align: left;
+    }
+
+    .midjourney-status-refresh {
+        justify-self: start;
     }
 }
 

--- a/public/assets/js/midjourney.js
+++ b/public/assets/js/midjourney.js
@@ -1,0 +1,95 @@
+const statusContainer = document.querySelector('[data-midjourney-status]');
+
+if (statusContainer) {
+    const indicator = statusContainer.querySelector('[data-status-indicator]');
+    const statusText = statusContainer.querySelector('[data-status-text]');
+    const statusDetails = statusContainer.querySelector('[data-status-details]');
+    const refreshButton = statusContainer.querySelector('[data-status-refresh]');
+
+    const renderState = (state, { message, details, upstream } = {}) => {
+        statusContainer.dataset.state = state;
+
+        if (indicator) {
+            indicator.dataset.state = state;
+        }
+
+        if (statusText) {
+            statusText.textContent = message ?? '';
+        }
+
+        if (statusDetails) {
+            let detailText = '';
+            if (upstream) {
+                try {
+                    detailText = JSON.stringify(upstream, null, 2);
+                } catch (error) {
+                    detailText = String(upstream);
+                }
+            } else if (details) {
+                detailText = details;
+            }
+
+            statusDetails.hidden = !detailText;
+            statusDetails.textContent = detailText;
+        }
+    };
+
+    const setLoading = () => {
+        renderState('loading', { message: 'Checking proxy status…' });
+    };
+
+    const setSuccess = (payload) => {
+        const message = payload.message ?? 'Midjourney proxy is online.';
+        renderState('connected', {
+            message,
+            details: payload.message && !payload.upstream ? payload.message : undefined,
+            upstream: payload.upstream,
+        });
+    };
+
+    const setError = (error) => {
+        const message = error?.message ?? error?.error ?? 'Unable to contact the Midjourney proxy.';
+        const details = error?.details ?? error?.error;
+        renderState('error', { message, details });
+    };
+
+    const fetchStatus = async () => {
+        setLoading();
+        try {
+            const response = await fetch('/api/midjourney/status', {
+                headers: { Accept: 'application/json' },
+            });
+
+            let payload;
+            try {
+                payload = await response.clone().json();
+            } catch {
+                const fallback = await response.text();
+                payload = {
+                    ok: false,
+                    message: fallback || 'Midjourney proxy returned a non-JSON response.',
+                };
+            }
+
+            if (response.ok && payload.ok) {
+                setSuccess(payload);
+            } else {
+                setError({
+                    message: payload.error ?? payload.message ?? 'Midjourney proxy is offline.',
+                    details: payload.message,
+                });
+            }
+        } catch (error) {
+            setError({ message: error.message });
+        }
+    };
+
+    if (refreshButton) {
+        refreshButton.addEventListener('click', (event) => {
+            event.preventDefault();
+            fetchStatus();
+        });
+    }
+
+    fetchStatus();
+}

--- a/public/midjourney.html
+++ b/public/midjourney.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/styles.css">
     <script type="module" src="/assets/js/site.js" defer></script>
+    <script type="module" src="/assets/js/midjourney.js" defer></script>
     <script type="module" src="https://unpkg.com/lucide@latest" defer></script>
 </head>
 <body data-page="midjourney">
@@ -55,6 +56,17 @@
                         <li>Expose the proxy endpoint (for example, <code>https://your-proxy.example.com</code>) and confirm <code>/mj</code> responds with the available APIs.</li>
                         <li>Open the settings panel inside the Midjourney deck, paste the proxy URL, and authenticate. The UI immediately syncs queued jobs and prompt presets.</li>
                     </ol>
+                    <div class="midjourney-status" data-midjourney-status data-state="loading">
+                        <div class="midjourney-status-indicator" data-status-indicator aria-hidden="true"></div>
+                        <div class="midjourney-status-body">
+                            <p class="midjourney-status-text" data-status-text>Checking proxy status…</p>
+                            <pre class="midjourney-status-details" data-status-details hidden></pre>
+                        </div>
+                        <button class="midjourney-status-refresh" type="button" data-status-refresh>
+                            <i data-lucide="refresh-ccw"></i>
+                            Refresh
+                        </button>
+                    </div>
                     <p class="midjourney-note">
                         Need the full runbook? Follow the official setup guide bundled with the Lobe Midjourney Web UI repository for port mappings, optional task stores, and advanced tuning tips.
                     </p>

--- a/tests/midjourney-proxy.test.js
+++ b/tests/midjourney-proxy.test.js
@@ -1,0 +1,185 @@
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { proxyToMidjourney, midjourneyStatus } from '../lib/midjourney-proxy.js';
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+    globalThis.fetch = async () =>
+        new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        });
+});
+
+after(() => {
+    globalThis.fetch = originalFetch;
+});
+
+const decodeBody = (input) => {
+    if (!input) {
+        return '';
+    }
+
+    if (typeof input === 'string') {
+        return input;
+    }
+
+    if (input instanceof ArrayBuffer) {
+        return Buffer.from(input).toString();
+    }
+
+    return Buffer.from(input).toString();
+};
+
+test('proxyToMidjourney forwards path, query, headers, and method', async () => {
+    const requests = [];
+    globalThis.fetch = async (input, init) => {
+        requests.push({ input, init });
+        return new Response('{"jobs":[]}', {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        });
+    };
+
+    const request = new Request('https://hacktech.example/api/midjourney/mj/status?foo=bar');
+
+    const response = await proxyToMidjourney(
+        {
+            env: { MIDJOURNEY_PROXY_URL: 'https://proxy.example.com' },
+            request,
+        },
+        ['mj', 'status']
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].input, 'https://proxy.example.com/mj/status?foo=bar');
+    assert.equal(requests[0].init.method, 'GET');
+    assert.equal(requests[0].init.headers.get('origin'), 'https://proxy.example.com');
+    assert.equal(response.headers.get('access-control-allow-origin'), '*');
+
+    const body = await response.text();
+    assert.equal(body, '{"jobs":[]}');
+});
+
+test('proxyToMidjourney forwards request bodies for mutations', async () => {
+    const requests = [];
+    globalThis.fetch = async (input, init) => {
+        requests.push({ input, init });
+        return new Response('{"id":"task-123"}', {
+            status: 202,
+            headers: { 'content-type': 'application/json' },
+        });
+    };
+
+    const request = new Request('https://hacktech.example/api/midjourney/mj/task', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ prompt: 'image payload' }),
+    });
+
+    const response = await proxyToMidjourney(
+        {
+            env: { MIDJOURNEY_PROXY_URL: 'https://proxy.example.com' },
+            request,
+        },
+        ['mj', 'task']
+    );
+
+    assert.equal(response.status, 202);
+    assert.equal(requests.length, 1);
+    assert.equal(decodeBody(requests[0].init.body), JSON.stringify({ prompt: 'image payload' }));
+});
+
+test('proxyToMidjourney returns configuration errors as JSON', async () => {
+    const response = await proxyToMidjourney(
+        {
+            env: {},
+            request: new Request('https://hacktech.example/api/midjourney'),
+        },
+        []
+    );
+
+    assert.equal(response.status, 500);
+    const payload = await response.json();
+    assert.match(payload.error, /not configured/i);
+});
+
+test('midjourneyStatus reports upstream success details', async () => {
+    globalThis.fetch = async () =>
+        new Response(
+            JSON.stringify({ version: '1.2.3', routes: ['/mj/task'] }),
+            {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            }
+        );
+
+    const response = await midjourneyStatus({
+        env: { MIDJOURNEY_PROXY_URL: 'https://proxy.example.com' },
+        request: new Request('https://hacktech.example/api/midjourney/status'),
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.upstreamStatus, 200);
+    assert.deepEqual(payload.upstream, { version: '1.2.3', routes: ['/mj/task'] });
+    assert.match(payload.message, /responded successfully/i);
+});
+
+test('midjourneyStatus surfaces upstream failures', async () => {
+    globalThis.fetch = async () =>
+        new Response('proxy down', {
+            status: 503,
+            headers: { 'content-type': 'text/plain' },
+        });
+
+    const response = await midjourneyStatus({
+        env: { MIDJOURNEY_PROXY_URL: 'https://proxy.example.com' },
+        request: new Request('https://hacktech.example/api/midjourney/status'),
+    });
+
+    assert.equal(response.status, 502);
+    const payload = await response.json();
+    assert.equal(payload.ok, false);
+    assert.equal(payload.upstreamStatus, 503);
+    assert.match(payload.error, /proxy down/i);
+});
+
+test('midjourneyStatus enforces method restrictions', async () => {
+    const response = await midjourneyStatus({
+        env: { MIDJOURNEY_PROXY_URL: 'https://proxy.example.com' },
+        request: new Request('https://hacktech.example/api/midjourney/status', { method: 'POST' }),
+    });
+
+    assert.equal(response.status, 405);
+    assert.match((await response.json()).error, /method not allowed/i);
+});
+
+test('midjourneyStatus returns configuration errors clearly', async () => {
+    const response = await midjourneyStatus({
+        env: {},
+        request: new Request('https://hacktech.example/api/midjourney/status'),
+    });
+
+    assert.equal(response.status, 500);
+    const payload = await response.json();
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /not configured/i);
+});
+
+test('proxyToMidjourney handles preflight requests', async () => {
+    const response = await proxyToMidjourney(
+        {
+            env: { MIDJOURNEY_PROXY_URL: 'https://proxy.example.com' },
+            request: new Request('https://hacktech.example/api/midjourney', { method: 'OPTIONS' }),
+        },
+        []
+    );
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('access-control-allow-origin'), '*');
+});


### PR DESCRIPTION
## Summary
- add Cloudflare Pages proxy functions for Midjourney requests, including a status endpoint backed by shared proxy utilities
- wire the Midjourney page with a live status widget, styling, and documentation for the new MIDJOURNEY_PROXY_URL variable
- cover the proxy and status flows with unit tests to guard request forwarding, error handling, and CORS behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddfa922ad48327b78818654d29662c