### PR TITLE
Add analyst chat console and ethical hacking tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This repository contains a static, multi-page version of the original HackTech e
 ## Project structure
 
 ```
-public/
-  index.html                # Landing page
-  daily-briefing.html       # AI briefing page powered by Cloudflare Workers AI
-  breach-archives.html      # Historical case studies
-  arsenal.html              # Curated tooling collection
-  contact.html              # Secure contact form instructions
+  public/
+    index.html                # Landing page
+    daily-briefing.html       # AI briefing page powered by Cloudflare Workers AI
+    chat-console.html         # Dedicated analyst console backed by Workers AI chat
+    ethical-hacking-tutorials.html # Curated training tracks and resources
+    breach-archives.html      # Historical case studies
+    arsenal.html              # Curated tooling collection
+    contact.html              # Secure contact form instructions
   assets/
     css/styles.css          # Shared visual design
     js/matrix.js            # Matrix rain background effect

--- a/public/arsenal.html
+++ b/public/arsenal.html
@@ -22,6 +22,8 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="chat" href="/chat-console.html"> <i data-lucide="messages-square"></i> Analyst Chat</a>
+            <a class="nav-link" data-nav-link data-page-target="tutorials" href="/ethical-hacking-tutorials.html"> <i data-lucide="book-open-check"></i> Tutorials</a>
             <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -316,6 +316,50 @@ nav {
     box-shadow: none;
 }
 
+.chat-layout {
+    display: grid;
+    gap: 1.75rem;
+    margin-top: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+    .chat-layout {
+        grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+        align-items: start;
+    }
+}
+
+.chat-intel {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.quick-prompts {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.6rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.quick-prompts li::marker {
+    color: var(--color-neon-primary);
+}
+
+.legal-note {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    border-left: 0.2rem solid rgba(255, 255, 255, 0.18);
+    background: rgba(0, 0, 0, 0.25);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 179, 189, 0.85);
+}
+
 .sr-only {
     position: absolute;
     width: 1px;
@@ -346,6 +390,61 @@ nav {
     margin: 1.5rem 0;
     font-family: 'Roboto Mono', monospace;
     font-size: 0.95rem;
+}
+
+.tutorial-grid {
+    display: grid;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+    .tutorial-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.tutorial-card {
+    display: grid;
+    gap: 1rem;
+}
+
+.tutorial-card h3 {
+    margin: 0;
+    font-size: 1.35rem;
+    letter-spacing: 0.06em;
+    color: rgba(204, 255, 214, 0.95);
+}
+
+.tutorial-meta {
+    display: inline-flex;
+    gap: 0.6rem;
+    align-items: center;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.tutorial-topics {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 0.55rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.88rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.tutorial-topics li::marker {
+    color: var(--color-neon-primary);
+}
+
+.tutorial-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
 }
 
 .grid {

--- a/public/assets/js/chat.js
+++ b/public/assets/js/chat.js
@@ -1,7 +1,7 @@
 const systemMessage = {
     role: 'system',
     content:
-        'You are a world-class cybersecurity analyst assisting the HackTech Daily Briefing audience. Provide concise, technically accurate insights and suggest next steps when helpful.',
+        'You are a world-class cybersecurity analyst supporting HackTech operators across briefings and training missions. Provide concise, technically accurate insights, emphasize lawful defensive actions, and suggest next steps when helpful.',
 };
 
 const conversation = [systemMessage];
@@ -154,12 +154,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     appendMessage(
         'assistant',
-        'Welcome back, operative. I can expand on any briefing item, analyze potential impact, or suggest mitigation steps. What intel do you need?'
+        'Welcome back, operative. I can expand on briefing intel, craft training plans, or outline mitigation steps. What signal should we decode first?'
     );
     conversation.push({
         role: 'assistant',
         content:
-            'Welcome back, operative. I can expand on any briefing item, analyze potential impact, or suggest mitigation steps. What intel do you need?',
+            'Welcome back, operative. I can expand on briefing intel, craft training plans, or outline mitigation steps. What signal should we decode first?',
     });
 
     form.addEventListener('submit', transmitMessage);

--- a/public/breach-archives.html
+++ b/public/breach-archives.html
@@ -22,6 +22,8 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="chat" href="/chat-console.html"> <i data-lucide="messages-square"></i> Analyst Chat</a>
+            <a class="nav-link" data-nav-link data-page-target="tutorials" href="/ethical-hacking-tutorials.html"> <i data-lucide="book-open-check"></i> Tutorials</a>
             <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>

--- a/public/chat-console.html
+++ b/public/chat-console.html
@@ -3,17 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HackTech Daily Briefing</title>
+    <title>Analyst Chat Console | HackTech</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/styles.css">
     <script type="module" src="/assets/js/site.js" defer></script>
     <script type="module" src="https://unpkg.com/lucide@latest" defer></script>
-    <script src="/assets/js/briefing.js" defer></script>
     <script src="/assets/js/chat.js" defer></script>
 </head>
-<body data-page="daily">
+<body data-page="chat">
     <canvas id="matrixCanvas" class="matrix-canvas"></canvas>
     <div class="scanline-overlay"></div>
     <main class="container">
@@ -31,26 +30,35 @@
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>
         </nav>
-        <div class="briefing-layout">
-            <section class="cyber-panel" aria-labelledby="daily-briefing-heading">
-                <h2 id="daily-briefing-heading"><i data-lucide="shield-check"></i> AI-Powered Daily Briefing</h2>
-                <div id="briefing-content" class="font-mono" style="text-align: center;">
-                    <p>Fetching latest intel from the grid...</p>
-                    <div class="loading-dots" style="justify-content: center; margin-top: 1.5rem;">
-                        <span></span>
-                        <span></span>
-                        <span></span>
-                    </div>
+        <section class="cyber-panel" aria-labelledby="chat-console-heading">
+            <h2 id="chat-console-heading"><i data-lucide="messages-square"></i> Analyst Chat Console</h2>
+            <p class="highlight">
+                The console links you directly with HackTech's embedded analyst. Ask for deeper context on a briefing item, talk through mitigation strategies, or map the next steps of an engagement. Responses are sourced from Cloudflare Workers AI and tuned for lawful, defensive operations.
+            </p>
+            <div class="chat-layout">
+                <div class="chat-intel">
+                    <article class="data-card" style="display: grid; gap: 0.85rem;">
+                        <h3 class="font-mono" style="margin: 0; font-size: 1.1rem; letter-spacing: 0.08em; color: rgba(204,255,214,0.95);">Signal Boost: Suggested Prompts</h3>
+                        <ul class="quick-prompts">
+                            <li>"Summarize likely impact of the latest briefing for a healthcare SOC."</li>
+                            <li>"Outline immediate containment steps for a suspected ransomware beacon."</li>
+                            <li>"Compare tooling choices for external recon versus internal threat hunting."</li>
+                            <li>"Map MITRE ATT&amp;CK techniques involved in a supply-chain intrusion."</li>
+                        </ul>
+                    </article>
+                    <article class="data-card" style="display: grid; gap: 0.85rem;">
+                        <h3 class="font-mono" style="margin: 0; font-size: 1.1rem; letter-spacing: 0.08em; color: rgba(204,255,214,0.95);">Usage Protocol</h3>
+                        <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
+                            The analyst focuses on authorized testing, defense, and incident response. Keep transmissions free of personal data, and never attempt unauthorized access. Consult the tutorials deck for hands-on practice environments before working in production.
+                        </p>
+                        <p class="legal-note">Operate responsibly. Confirm you have written authorization before executing any intrusive action.</p>
+                    </article>
                 </div>
-            </section>
-
-            <section class="cyber-panel" id="analyst-chat" aria-labelledby="analyst-chat-heading">
-                <h2 id="analyst-chat-heading"><i data-lucide="messages-square"></i> Analyst Chat Console</h2>
                 <div class="chat-wrapper" data-chat-wrapper>
                     <div class="chat-thread" id="chat-thread" aria-live="polite" aria-busy="false"></div>
                     <form id="chat-form" class="chat-form" autocomplete="off">
                         <label class="sr-only" for="chat-input">Send a message to the HackTech analyst</label>
-                        <textarea id="chat-input" class="chat-input font-mono" name="message" rows="3" placeholder="Ask the analyst to expand on any threat, mitigation, or tooling..." required></textarea>
+                        <textarea id="chat-input" class="chat-input font-mono" name="message" rows="3" placeholder="Ask the analyst to expand on a threat, mitigation, or workflow..." required></textarea>
                         <div class="chat-actions">
                             <span class="chat-hint font-mono">Shift + Enter for new line</span>
                             <button type="submit" class="chat-send" data-chat-send>
@@ -60,8 +68,8 @@
                         </div>
                     </form>
                 </div>
-            </section>
-        </div>
+            </div>
+        </section>
         <footer>
             <div class="socials">
                 <a href="https://facebook.com/YOUR_PAGE_HERE" target="_blank" rel="noopener noreferrer" aria-label="Facebook">

--- a/public/contact.html
+++ b/public/contact.html
@@ -22,6 +22,8 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="chat" href="/chat-console.html"> <i data-lucide="messages-square"></i> Analyst Chat</a>
+            <a class="nav-link" data-nav-link data-page-target="tutorials" href="/ethical-hacking-tutorials.html"> <i data-lucide="book-open-check"></i> Tutorials</a>
             <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>

--- a/public/ethical-hacking-tutorials.html
+++ b/public/ethical-hacking-tutorials.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ethical Hacking Tutorials | HackTech</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/styles.css">
+    <script type="module" src="/assets/js/site.js" defer></script>
+    <script type="module" src="https://unpkg.com/lucide@latest" defer></script>
+</head>
+<body data-page="tutorials">
+    <canvas id="matrixCanvas" class="matrix-canvas"></canvas>
+    <div class="scanline-overlay"></div>
+    <main class="container">
+        <header>
+            <h1 class="site-title">HackTech</h1>
+            <p class="site-subtitle">:: YOUR SOURCE FOR CYBER INTELLIGENCE ::</p>
+        </header>
+        <nav>
+            <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
+            <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="chat" href="/chat-console.html"> <i data-lucide="messages-square"></i> Analyst Chat</a>
+            <a class="nav-link" data-nav-link data-page-target="tutorials" href="/ethical-hacking-tutorials.html"> <i data-lucide="book-open-check"></i> Tutorials</a>
+            <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
+            <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
+            <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
+            <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>
+        </nav>
+        <section class="cyber-panel" aria-labelledby="tutorials-heading">
+            <h2 id="tutorials-heading"><i data-lucide="book-open-check"></i> Ethical Hacking Tutorials</h2>
+            <p class="highlight">
+                Build expertise the right way. Each track below combines trusted study material, hands-on labs, and professional certifications to reinforce lawful, defensible security practice. Pair them with the Analyst Chat console whenever you need clarification or a tailored learning plan.
+            </p>
+            <div class="tutorial-grid">
+                <article class="data-card tutorial-card">
+                    <h3 class="font-mono">Foundations &amp; Certifications</h3>
+                    <div class="tutorial-meta">
+                        <i data-lucide="layers"></i>
+                        <span>Skill Floor</span>
+                    </div>
+                    <ul class="tutorial-topics">
+                        <li>Study CompTIA Security+ or Network+ to cement terminology, protocols, and defensive patterns.</li>
+                        <li>Follow TryHackMe's "Pre-Security" and "Jr Penetration Tester" learning paths for guided labs.</li>
+                        <li>Track progress with a personal runbook and collect write-ups for every lab completed.</li>
+                    </ul>
+                    <div class="tutorial-actions">
+                        <a class="resource-link" href="https://tryhackme.com/path/outline/presecurity" target="_blank" rel="noopener noreferrer">
+                            <span>TryHackMe Pre-Security</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                        <a class="resource-link" href="https://www.comptia.org/certifications/security" target="_blank" rel="noopener noreferrer">
+                            <span>CompTIA Security+</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
+                </article>
+                <article class="data-card tutorial-card">
+                    <h3 class="font-mono">Hands-On Lab Operations</h3>
+                    <div class="tutorial-meta">
+                        <i data-lucide="target"></i>
+                        <span>Practice Ranges</span>
+                    </div>
+                    <ul class="tutorial-topics">
+                        <li>Spin up the OWASP Juice Shop or WebGoat locally to learn application security through deliberate exploitation.</li>
+                        <li>Enroll in Hack The Box Academy modules focused on enumeration, privilege escalation, and Active Directory.</li>
+                        <li>Document every attack chain, highlighting detection opportunities for blue teams.</li>
+                    </ul>
+                    <div class="tutorial-actions">
+                        <a class="resource-link" href="https://owasp.org/www-project-juice-shop/" target="_blank" rel="noopener noreferrer">
+                            <span>OWASP Juice Shop</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                        <a class="resource-link" href="https://academy.hackthebox.com/" target="_blank" rel="noopener noreferrer">
+                            <span>Hack The Box Academy</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
+                </article>
+                <article class="data-card tutorial-card">
+                    <h3 class="font-mono">Defensive Countermeasures</h3>
+                    <div class="tutorial-meta">
+                        <i data-lucide="shield"></i>
+                        <span>Blue Team</span>
+                    </div>
+                    <ul class="tutorial-topics">
+                        <li>Complete the SANS Blue Team Operations exercises or the open Sigma rules workshops to sharpen detection engineering.</li>
+                        <li>Deploy the Elastic Security or Wazuh stack in a lab to practice log ingestion, correlation, and automated response.</li>
+                        <li>Use MITRE D3FEND to map remediations against observed ATT&amp;CK techniques.</li>
+                    </ul>
+                    <div class="tutorial-actions">
+                        <a class="resource-link" href="https://www.elastic.co/security-labs" target="_blank" rel="noopener noreferrer">
+                            <span>Elastic Security Labs</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                        <a class="resource-link" href="https://github.com/wazuh/wazuh" target="_blank" rel="noopener noreferrer">
+                            <span>Deploy Wazuh</span>
+                            <i data-lucide="github"></i>
+                        </a>
+                    </div>
+                </article>
+                <article class="data-card tutorial-card">
+                    <h3 class="font-mono">Operational Playbooks</h3>
+                    <div class="tutorial-meta">
+                        <i data-lucide="book-marked"></i>
+                        <span>Process</span>
+                    </div>
+                    <ul class="tutorial-topics">
+                        <li>Study NIST SP 800-115 and 800-61 to understand formal testing methodology and incident handling.</li>
+                        <li>Build a repeatable rules-of-engagement template covering scope, escalation, and evidence handling.</li>
+                        <li>Review real-world post-incident reports and convert lessons learned into tabletop drills.</li>
+                    </ul>
+                    <div class="tutorial-actions">
+                        <a class="resource-link" href="https://csrc.nist.gov/publications/detail/sp/800-115/rev-1/draft" target="_blank" rel="noopener noreferrer">
+                            <span>NIST SP 800-115</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                        <a class="resource-link" href="https://www.mitre.org/impact/d3fend" target="_blank" rel="noopener noreferrer">
+                            <span>MITRE D3FEND</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
+                </article>
+            </div>
+            <p class="legal-note" style="margin-top: 2rem;">Training resources are for authorized research and defense. Always respect privacy, terms of service, and local regulations.</p>
+        </section>
+        <footer>
+            <div class="socials">
+                <a href="https://facebook.com/YOUR_PAGE_HERE" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/></svg>
+                </a>
+            </div>
+            // HackTech &copy; 2024. Information for educational purposes only. //
+        </footer>
+    </main>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,8 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="chat" href="/chat-console.html"> <i data-lucide="messages-square"></i> Analyst Chat</a>
+            <a class="nav-link" data-nav-link data-page-target="tutorials" href="/ethical-hacking-tutorials.html"> <i data-lucide="book-open-check"></i> Tutorials</a>
             <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>
@@ -44,10 +46,20 @@
             </div>
         </section>
         <section class="cyber-panel">
-            <h2><i data-lucide="message-circle"></i> Active Chat: Memorable Text Entry</h2>
+            <h2><i data-lucide="message-circle"></i> Active Chat &amp; Guided Training</h2>
             <p class="highlight">
-                Engage with the HackTech community through our active chat hub. Drop in memorable intel, share defensive tactics, and keep the conversation thriving with every text you enter.
+                Engage with the on-call HackTech analyst for instant clarification and continue sharpening your craft with curated, ethics-first tutorials. Every transmission and lesson is designed to keep operators sharp, informed, and on-mission.
             </p>
+            <div class="grid grid-two">
+                <a class="data-card" href="/chat-console.html">
+                    <h3 class="font-mono" style="color: var(--color-neon-primary); letter-spacing: 0.1em;">Analyst Chat Console</h3>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem;">Link up with the embedded analyst for rapid threat triage, mitigation advice, and tool selection guidance.</p>
+                </a>
+                <a class="data-card" href="/ethical-hacking-tutorials.html">
+                    <h3 class="font-mono" style="color: var(--color-neon-primary); letter-spacing: 0.1em;">Ethical Hacking Tutorials</h3>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem;">Work through structured learning paths, labs, and certification prep engineered to reinforce lawful security operations.</p>
+                </a>
+            </div>
         </section>
         <footer>
             <div class="socials">

--- a/public/midjourney.html
+++ b/public/midjourney.html
@@ -23,6 +23,8 @@
         <nav>
             <a class="nav-link" data-nav-link data-page-target="home" href="/index.html"> <i data-lucide="scan"></i> Home</a>
             <a class="nav-link" data-nav-link data-page-target="daily" href="/daily-briefing.html"> <i data-lucide="shield-check"></i> Daily Briefing</a>
+            <a class="nav-link" data-nav-link data-page-target="chat" href="/chat-console.html"> <i data-lucide="messages-square"></i> Analyst Chat</a>
+            <a class="nav-link" data-nav-link data-page-target="tutorials" href="/ethical-hacking-tutorials.html"> <i data-lucide="book-open-check"></i> Tutorials</a>
             <a class="nav-link" data-nav-link data-page-target="midjourney" href="/midjourney.html"> <i data-lucide="sparkles"></i> Midjourney</a>
             <a class="nav-link" data-nav-link data-page-target="breaches" href="/breach-archives.html"> <i data-lucide="shield-alert"></i> Breach Archives</a>
             <a class="nav-link" data-nav-link data-page-target="arsenal" href="/arsenal.html"> <i data-lucide="wrench"></i> Arsenal</a>


### PR DESCRIPTION
## Summary
- add a dedicated Analyst Chat console page that reuses the Workers AI endpoint and provides prompt and usage guidance
- publish an ethical hacking tutorials page with curated study tracks, lab links, and compliance reminders
- update global navigation, styling, and chat copy to surface the new experiences across the site

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfd38c767083279b88ea0285668dd8