### PR TITLE
Add hardware assessment gear section to arsenal page

### DIFF
--- a/public/arsenal.html
+++ b/public/arsenal.html
@@ -117,6 +117,78 @@
                 </article>
             </div>
         </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="cpu"></i> Hardware &amp; Physical Assessment Gear</h2>
+            <p class="highlight">
+                Compact hardware implants and testing devices can help red-teamers evaluate defenses in real-world environments. Always obtain explicit authorization before deploying any of the equipment below.
+            </p>
+            <div class="grid" style="gap: 1.75rem;">
+                <article class="data-card">
+                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 WiFi Pineapple</p>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
+                        A portable wireless auditing platform designed to help security teams identify rogue access points and run controlled man-in-the-middle simulations. Modern models support cloud management, modular payloads, and detailed reporting for authorized assessments.
+                    </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://hak5.org/products/wifi-pineapple" target="_blank" rel="noopener noreferrer">
+                            <span>Official Product Page</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
+                </article>
+                <article class="data-card">
+                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 USB Rubber Ducky</p>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
+                        A programmable keystroke injection tool that emulates a trusted USB keyboard. Security practitioners leverage it to demonstrate the impact of unattended workstations and to test endpoint defenses against rapid payload delivery.
+                    </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://hak5.org/products/usb-rubber-ducky" target="_blank" rel="noopener noreferrer">
+                            <span>Learn More</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
+                </article>
+                <article class="data-card">
+                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 Key Croc</p>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
+                        A network-enabled keylogging implant that bridges between a keyboard and computer. When deployed in sanctioned security engagements, it helps blue teams understand the risk posed by physical access and monitor for unauthorized keystrokes in controlled scenarios.
+                    </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://hak5.org/products/key-croc" target="_blank" rel="noopener noreferrer">
+                            <span>Product Details</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
+                </article>
+                <article class="data-card">
+                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Proxmark3</p>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
+                        An advanced RFID/NFC research platform that supports sniffing, reading, emulation, and analysis of a broad range of tags. It is widely used in labs to evaluate physical access control systems, develop mitigation strategies, and train security personnel.
+                    </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://proxmark.com/cart" target="_blank" rel="noopener noreferrer">
+                            <span>Proxmark3 Kits</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                        <a class="resource-link" href="https://github.com/RfidResearchGroup/proxmark3" target="_blank" rel="noopener noreferrer">
+                            <span>Open Source Firmware</span>
+                            <i data-lucide="github"></i>
+                        </a>
+                    </div>
+                </article>
+                <article class="data-card">
+                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Flipper Zero</p>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
+                        A portable multi-tool for pentesters and hardware hackers featuring radio, RFID, infrared, and GPIO interfaces. Within authorized engagements, it serves as a Swiss Army knife for quick protocol reconnaissance and testing of embedded devices.
+                    </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://flipperzero.one/" target="_blank" rel="noopener noreferrer">
+                            <span>Flipper Zero Site</span>
+                            <i data-lucide="external-link"></i>
+                        </a>
+                    </div>
+                </article>
+            </div>
+        </section>
         <footer>
             <div class="socials">
                 <a href="https://facebook.com/YOUR_PAGE_HERE" target="_blank" rel="noopener noreferrer" aria-label="Facebook">


### PR DESCRIPTION
## Summary
- add a dedicated hardware and physical assessment section to the arsenal page
- describe widely used penetration testing devices with emphasis on authorized use
- link to official product resources for further reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e363bed34c8327bff945b342f1337b