### PR TITLE
Add GHunt OSINT tool to arsenal page

### DIFF
--- a/public/arsenal.html
+++ b/public/arsenal.html
@@ -115,6 +115,18 @@
                         </a>
                     </div>
                 </article>
+                <article class="data-card">
+                    <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">GHunt</p>
+                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
+                        An OSINT framework for investigating Google accounts, GHunt aggregates public metadata from services like Gmail, Photos, and Maps to surface associations, aliases, and activity signals useful during reconnaissance.
+                    </p>
+                    <div class="resource-actions">
+                        <a class="resource-link" href="https://github.com/mxrch/GHunt" target="_blank" rel="noopener noreferrer">
+                            <span>Explore GHunt on GitHub</span>
+                            <i data-lucide="github"></i>
+                        </a>
+                    </div>
+                </article>
             </div>
         </section>
         <footer>


### PR DESCRIPTION
## Summary
- add GHunt OSINT framework to the arsenal tools list with a short description
- link to the official GitHub repository for easy access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3620a7bc88327b2dd216cdb83af97