### PR TITLE
Add serverless contact form with email delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains a static, multi-page version of the original HackTech e
     ethical-hacking-tutorials.html # Curated training tracks and resources
     breach-archives.html      # Historical case studies
     arsenal.html              # Curated tooling collection
-    contact.html              # Secure contact form instructions
+    contact.html              # Secure contact form powered by Pages Functions
   assets/
     css/styles.css          # Shared visual design
     js/matrix.js            # Matrix rain background effect
@@ -66,7 +66,11 @@ functions/
 
 - **Daily Briefing**: The front end calls `/api/briefing`, which in turn invokes Cloudflare's `@cf/meta/llama-3-8b-instruct` model. Adjust the prompt in `functions/api/briefing.js` or point it at a different [Cloudflare AI model](https://developers.cloudflare.com/workers-ai/models/) by changing the endpoint path.
 - **Midjourney deck**: Configure `MIDJOURNEY_PROXY_URL` to point at your Midjourney proxy. Pages Functions expose `/api/midjourney/*` as a CORS-enabled pass-through so the embedded Lobe Midjourney UI can route imagine/upscale calls securely. Hit `/api/midjourney/status` to confirm the proxy is reachable—responses include a summarized payload from `/mj`.
-- **Contact form**: Replace `YOUR_UNIQUE_FORMSPREE_ENDPOINT` in `public/contact.html` with the endpoint provided by Formspree (or swap in your preferred provider).
+- **Contact form**: Submissions are routed through `functions/api/contact.js`, which delivers email via MailChannels. Set the following environment variables in Cloudflare Pages → **Functions** → **Environment variables** to customize the delivery details:
+  - `CONTACT_TO_EMAIL` → Destination inbox (defaults to `hoya282@gmail.com`).
+  - `CONTACT_FROM_EMAIL` → Sender address used with MailChannels (defaults to `no-reply@hacktech-contact.pages.dev`).
+  - `CONTACT_FROM_NAME` → Optional human-friendly sender name for the email envelope.
+  The static form POSTs to `/api/contact` and includes progressive enhancement for live status updates.
 
 ## Notes
 

--- a/functions/api/contact.js
+++ b/functions/api/contact.js
@@ -1,0 +1,185 @@
+export const onRequestPost = async ({ request, env }) => {
+    try {
+        const formData = await request.formData();
+        const handle = (formData.get('handle') || '').toString().trim();
+        const replyTo = (formData.get('reply_to') || '').toString().trim();
+        const message = (formData.get('message') || '').toString().trim();
+
+        if (!message) {
+            return createResponse({
+                status: 'error',
+                message: 'Message content is required.'
+            }, 400, request);
+        }
+
+        const toEmail = (env.CONTACT_TO_EMAIL || 'hoya282@gmail.com').trim();
+        if (!toEmail) {
+            return createResponse({
+                status: 'error',
+                message: 'Contact email destination is not configured.'
+            }, 500, request);
+        }
+
+        const fromEmail = (env.CONTACT_FROM_EMAIL || 'no-reply@hacktech-contact.pages.dev').trim();
+        const fromName = env.CONTACT_FROM_NAME || 'HackTech Contact Form';
+        const subjectHandle = handle || 'Unknown Operative';
+        const subject = `New HackTech contact from ${subjectHandle}`;
+
+        const plainBody = buildPlainBody({ handle, replyTo, message });
+        const htmlBody = buildHtmlBody({ handle, replyTo, message });
+
+        const mailPayload = {
+            personalizations: [
+                {
+                    to: [
+                        {
+                            email: toEmail,
+                        },
+                    ],
+                },
+            ],
+            from: {
+                email: fromEmail,
+                name: fromName,
+            },
+            subject,
+            content: [
+                {
+                    type: 'text/plain',
+                    value: plainBody,
+                },
+                {
+                    type: 'text/html',
+                    value: htmlBody,
+                },
+            ],
+        };
+
+        if (replyTo) {
+            mailPayload.reply_to = {
+                email: replyTo,
+            };
+        }
+
+        if (handle) {
+            mailPayload.personalizations[0].to[0].name = handle;
+        }
+
+        const response = await fetch('https://api.mailchannels.net/tx/v1/send', {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify(mailPayload),
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            return createResponse({
+                status: 'error',
+                message: 'Unable to transmit message.',
+                detail: errorText,
+            }, 502, request);
+        }
+
+        return createResponse({
+            status: 'success',
+            message: 'Transmission complete. We\'ll be in touch soon.',
+        }, 200, request);
+    } catch (error) {
+        return createResponse({
+            status: 'error',
+            message: 'An unexpected error occurred while processing the request.',
+            detail: error instanceof Error ? error.message : String(error),
+        }, 500, request);
+    }
+};
+
+const createResponse = (payload, status, request) => {
+    const accept = request.headers.get('accept') || '';
+    const headers = new Headers();
+
+    if (accept.includes('text/html')) {
+        headers.set('content-type', 'text/html; charset=utf-8');
+        return new Response(renderHtmlResponse(payload), {
+            status,
+            headers,
+        });
+    }
+
+    headers.set('content-type', 'application/json; charset=utf-8');
+    headers.set('cache-control', 'no-store');
+    return new Response(JSON.stringify(payload, null, 2), {
+        status,
+        headers,
+    });
+};
+
+const buildPlainBody = ({ handle, replyTo, message }) => {
+    const lines = [];
+    lines.push('Incoming secure contact message:');
+    lines.push('');
+    lines.push(`Handle: ${handle || 'N/A'}`);
+    lines.push(`Reply-To: ${replyTo || 'N/A'}`);
+    lines.push('');
+    lines.push('Message:');
+    lines.push(message);
+    lines.push('');
+    lines.push(`Received at: ${new Date().toISOString()}`);
+    return lines.join('\n');
+};
+
+const buildHtmlBody = ({ handle, replyTo, message }) => {
+    const escape = (value) =>
+        value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+
+    const safeHandle = handle ? escape(handle) : 'N/A';
+    const safeReplyTo = replyTo ? escape(replyTo) : 'N/A';
+    const safeMessage = message ? escape(message).replace(/\n/g, '<br>') : '';
+
+    return `<!doctype html>
+<html>
+  <body style="font-family: Arial, sans-serif; background-color: #0b0f1a; color: #f4f4f5; padding: 16px;">
+    <h2 style="margin-top: 0; color: #64f4ac;">HackTech secure contact message</h2>
+    <p><strong>Handle:</strong> ${safeHandle}</p>
+    <p><strong>Reply-To:</strong> ${safeReplyTo}</p>
+    <p><strong>Message</strong></p>
+    <div style="padding: 12px; background: rgba(100, 244, 172, 0.08); border-radius: 8px; line-height: 1.5; white-space: pre-wrap;">${safeMessage}</div>
+    <p style="margin-top: 24px; font-size: 0.875rem; color: rgba(244, 244, 245, 0.7);">Received at ${new Date().toISOString()}</p>
+  </body>
+</html>`;
+};
+
+const renderHtmlResponse = (payload) => {
+    const title = payload.status === 'success' ? 'Transmission Complete' : 'Transmission Error';
+    const accentColor = payload.status === 'success' ? '#64f4ac' : '#ff6b6b';
+
+    return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+    <style>
+      body { font-family: 'Inter', system-ui, sans-serif; background: #05060f; color: #f8fafc; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; padding: 24px; }
+      .panel { background: rgba(10, 15, 34, 0.95); border: 1px solid rgba(100, 244, 172, 0.25); border-radius: 16px; padding: 32px; max-width: 480px; text-align: center; box-shadow: 0 20px 60px rgba(5, 6, 15, 0.75); }
+      h1 { margin-top: 0; color: ${accentColor}; font-size: 1.75rem; }
+      p { line-height: 1.6; margin: 0 0 1rem 0; }
+      a { color: ${accentColor}; text-decoration: none; }
+      button { margin-top: 8px; background: ${accentColor}; color: #05060f; border: none; border-radius: 8px; padding: 0.75rem 1.5rem; font-weight: 700; cursor: pointer; }
+    </style>
+  </head>
+  <body>
+    <div class="panel">
+      <h1>${title}</h1>
+      <p>${payload.message || 'No additional details provided.'}</p>
+      ${payload.status === 'success' ? '<p>Return to <a href="/contact.html">Contact console</a>.</p>' : ''}
+      <button type="button" onclick="history.back()">Go Back</button>
+    </div>
+  </body>
+</html>`;
+};

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -626,6 +626,27 @@ button:hover {
     box-shadow: 0 0 30px rgba(0, 255, 136, 0.55);
 }
 
+.form-status {
+    margin-top: 0.25rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    min-height: 1.25rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.form-status[data-state='pending'] {
+    color: rgba(0, 255, 136, 0.75);
+}
+
+.form-status[data-state='success'] {
+    color: var(--color-neon-primary);
+}
+
+.form-status[data-state='error'] {
+    color: #ff6b6b;
+}
+
 .matrix-canvas {
     position: fixed;
     inset: 0;

--- a/public/assets/js/contact.js
+++ b/public/assets/js/contact.js
@@ -1,0 +1,51 @@
+const form = document.querySelector('[data-contact-form]');
+const statusEl = document.querySelector('[data-contact-status]');
+
+if (form) {
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        if (!statusEl) {
+            console.warn('Contact status element missing. Submission feedback will not be visible.');
+        } else {
+            statusEl.textContent = 'Transmitting secure packet...';
+            statusEl.dataset.state = 'pending';
+        }
+
+        try {
+            const formData = new FormData(form);
+            const response = await fetch(form.action, {
+                method: 'POST',
+                body: formData,
+            });
+
+            if (!response.ok) {
+                const errorPayload = await safeParseJson(response);
+                throw new Error(errorPayload?.message || `Request failed with status ${response.status}`);
+            }
+
+            if (statusEl) {
+                statusEl.textContent = 'Transmission successful. Expect a response soon.';
+                statusEl.dataset.state = 'success';
+            }
+
+            form.reset();
+        } catch (error) {
+            console.error('Contact form submission failed:', error);
+            if (statusEl) {
+                statusEl.textContent = error instanceof Error ? error.message : 'Unexpected error sending message.';
+                statusEl.dataset.state = 'error';
+            } else {
+                alert('Unable to send your message. Please try again later.');
+            }
+        }
+    });
+}
+
+async function safeParseJson(response) {
+    try {
+        return await response.clone().json();
+    } catch (error) {
+        return null;
+    }
+}

--- a/public/contact.html
+++ b/public/contact.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/styles.css">
     <script type="module" src="/assets/js/site.js" defer></script>
+    <script type="module" src="/assets/js/contact.js" defer></script>
     <script type="module" src="https://unpkg.com/lucide@latest" defer></script>
 </head>
 <body data-page="contact">
@@ -36,10 +37,10 @@
             </p>
             <div class="data-card" style="margin-bottom: 2rem;">
                 <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.85rem; line-height: 1.7;">
-                    <strong class="text-strong">Form integration tip:</strong> Create a free account at <a href="https://formspree.io/" target="_blank" rel="noopener noreferrer" style="color: var(--color-neon-primary);">Formspree</a> and copy your unique endpoint. Replace <code>YOUR_UNIQUE_FORMSPREE_ENDPOINT</code> in the form action below with that value to receive submissions directly in your inbox.
+                    <strong class="text-strong">Form integration tip:</strong> Messages are routed through our Cloudflare Pages Function and delivered via MailChannels. Update the <code>CONTACT_TO_EMAIL</code> environment variable to point at your preferred inbox—defaults to <code>hoya282@gmail.com</code>.
                 </p>
             </div>
-            <form action="https://formspree.io/f/YOUR_UNIQUE_FORMSPREE_ENDPOINT" method="POST">
+            <form action="/api/contact" method="POST" data-contact-form>
                 <div>
                     <label for="handle">HANDLE / ALIAS</label>
                     <input type="text" id="handle" name="handle" placeholder="Security_Researcher_01" required>
@@ -53,6 +54,7 @@
                     <textarea id="message" name="message" rows="5" placeholder="Enter your message here..." required></textarea>
                 </div>
                 <button type="submit">Transmit Data Packet</button>
+                <p class="form-status" data-contact-status role="status" aria-live="polite"></p>
             </form>
         </section>
         <footer>


### PR DESCRIPTION
## Summary
- replace the static Formspree action with a Cloudflare Pages Function that relays messages to MailChannels
- add progressive enhancement and status messaging for the contact form UI
- document the new configuration options for routing contact submissions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e382ecf91c8327aab8efe150241574