### PR TITLE
Map awesome-hacking catalog into HackTech content

### DIFF
--- a/public/arsenal.html
+++ b/public/arsenal.html
@@ -32,173 +32,432 @@
         <section class="cyber-panel">
             <h2><i data-lucide="terminal"></i> The Arsenal: Tools &amp; Platforms</h2>
             <p class="highlight">
-                A curated list of essential platforms and tools for security professionals. Authorization is required before using these on any network.
+                A complete redistribution of <em>awesome-hacking</em> tooling—each framework, image, and service placed into the
+                operating domains where it excels. Authorization is mandatory before running any capability described below.
             </p>
-            <div class="grid" style="gap: 1.75rem;">
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.5rem; color: rgba(204,255,204,0.95);">Kali Linux</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        An open-source, Debian-based Linux distribution geared towards various information security tasks, such as penetration testing, security research, computer forensics, and reverse engineering. It comes pre-installed with over 600 penetration-testing programs.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://www.kali.org/" target="_blank" rel="noopener noreferrer">
-                            <span>Visit Official Site</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.5rem; color: rgba(204,255,204,0.95);">Parrot OS</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A free and open-source Linux distribution based on Debian with a focus on security, privacy, and development. It includes a full portable laboratory for security and digital forensics experts, but it also includes all you need to develop your own software or keep your data secure.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://www.parrotsec.org/" target="_blank" rel="noopener noreferrer">
-                            <span>Explore Parrot OS</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.5rem; color: rgba(204,255,204,0.95);">Mobile Security &amp; Auditing</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        For developers and security professionals, specialized applications for rooted Android systems enable deep-level wireless network auditing and analysis. Frameworks like the Mobile Security Framework (MobSF) support comprehensive assessments across Android and iOS, while advanced toolkits demand expert knowledge and explicit permissions to operate legally and ethically.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://mobsf.github.io/docs/#/" target="_blank" rel="noopener noreferrer">
-                            <span>MobSF Documentation</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://github.com/MobSF/Mobile-Security-Framework-MobSF" target="_blank" rel="noopener noreferrer">
-                            <span>MobSF on GitHub</span>
-                            <i data-lucide="github"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">Nmap (Network Mapper)</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A free and open-source utility for network discovery and security auditing. It's used to discover hosts and services on a computer network by sending packets and analyzing the responses.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://nmap.org/" target="_blank" rel="noopener noreferrer">
-                            <span>Access Nmap</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">Wireshark</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A widely-used network protocol analyzer. It lets you see what's happening on your network at a microscopic level and is the de facto standard across many industries for troubleshooting and analysis.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://www.wireshark.org/" target="_blank" rel="noopener noreferrer">
-                            <span>Download Wireshark</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">Metasploit Framework</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        An open-source penetration testing framework. Security professionals use it to probe for systematic vulnerabilities on networks and servers to verify and validate security defenses.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://www.metasploit.com/" target="_blank" rel="noopener noreferrer">
-                            <span>Metasploit Platform</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://github.com/rapid7/metasploit-framework" target="_blank" rel="noopener noreferrer">
-                            <span>Metasploit on GitHub</span>
-                            <i data-lucide="github"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.25rem; color: rgba(204,255,204,0.95);">GHunt</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        An OSINT framework for investigating Google accounts, GHunt aggregates public metadata from services like Gmail, Photos, and Maps to surface associations, aliases, and activity signals useful during reconnaissance.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://github.com/mxrch/GHunt" target="_blank" rel="noopener noreferrer">
-                            <span>Explore GHunt on GitHub</span>
-                            <i data-lucide="github"></i>
-                        </a>
-                    </div>
-                </article>
+            <div class="resource-section">
+                <h3>Featured Operating Environments</h3>
+                <ul class="resource-list">
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://www.kali.org/" target="_blank" rel="noopener noreferrer">Kali Linux</a></p>
+                            <p class="resource-item-description">
+                                Debian-based distribution pre-loaded with hundreds of penetration-testing and forensics utilities.
+                                Use it as a portable red-team lab or baseline for capture-the-flag engagements.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://www.parrotsec.org/" target="_blank" rel="noopener noreferrer">Parrot OS</a></p>
+                            <p class="resource-item-description">
+                                Lightweight security-focused Linux that bundles privacy tooling, secure development stacks, and
+                                digital forensics suites for professionals who need a hardened daily driver.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://mobsf.github.io/docs/#/" target="_blank" rel="noopener noreferrer">Mobile Security &amp; Auditing</a></p>
+                            <p class="resource-item-description">
+                                Mobile Security Framework (MobSF) powers static and dynamic assessments across Android and iOS.
+                                Pair with rooted testing devices for lawful mobile application recon, malware triage, and wireless auditing.
+                            </p>
+                            <div class="resource-item-links">
+                                <a href="https://github.com/MobSF/Mobile-Security-Framework-MobSF" target="_blank" rel="noopener noreferrer">MobSF GitHub</a>
+                            </div>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>System Exploitation Frameworks</h3>
+                <ul class="resource-list compact">
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://github.com/rapid7/metasploit-framework" target="_blank" rel="noopener noreferrer">Metasploit</a></p>
+                            <p class="resource-item-description">
+                                Full-spectrum exploitation platform used to research vulnerabilities, validate detections, and automate post-exploitation workflows.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://github.com/gentilkiwi/mimikatz" target="_blank" rel="noopener noreferrer">mimikatz</a></p>
+                            <p class="resource-item-description">
+                                Essential Windows credential research toolkit providing Kerberos ticket manipulation, credential extraction, and more for authorized engagements.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://www.youtube.com/playlist?list=PLyzOVJj3bHQuiujH1lpn8cA9dsyulbYRv" target="_blank" rel="noopener noreferrer">Hackers tools Playlist</a></p>
+                            <p class="resource-item-description">
+                                Guided walk-through of staple offensive utilities—ideal for orienting junior analysts before they enter lab scenarios.
+                            </p>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Reconnaissance &amp; OSINT Utilities</h3>
+                <ul class="resource-list compact">
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://github.com/mxrch/GHunt" target="_blank" rel="noopener noreferrer">GHunt</a></p>
+                            <p class="resource-item-description">
+                                Investigate Google accounts through public metadata from Gmail, Photos, Maps, and related services to build lawful intelligence profiles.
+                            </p>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Docker Images for Penetration Testing &amp; Security</h3>
+                <ul class="resource-list compact">
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/kalilinux/kali-last-release/" target="_blank" rel="noopener noreferrer"><code>docker pull kalilinux/kali-linux-docker</code></a></p>
+                            <p class="resource-item-description">Official Kali Linux container delivering the entire toolkit on demand.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://github.com/zaproxy/zaproxy" target="_blank" rel="noopener noreferrer"><code>docker pull owasp/zap2docker-stable</code></a></p>
+                            <p class="resource-item-description">Official OWASP ZAP build for automated web vulnerability scanning inside containers.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/wpscanteam/wpscan/" target="_blank" rel="noopener noreferrer"><code>docker pull wpscanteam/wpscan</code></a></p>
+                            <p class="resource-item-description">Launch WPScan instantly to audit WordPress deployments without local installs.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/metasploitframework/metasploit-framework/" target="_blank" rel="noopener noreferrer"><code>docker pull metasploitframework/metasploit-framework</code></a></p>
+                            <p class="resource-item-description">Containerized Metasploit for transient lab or CI-based exploitation testing.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/citizenstig/dvwa/" target="_blank" rel="noopener noreferrer"><code>docker pull citizenstig/dvwa</code></a></p>
+                            <p class="resource-item-description">Spin up Damn Vulnerable Web Application (DVWA) to rehearse common web exploitation patterns.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/wpscanteam/vulnerablewordpress/" target="_blank" rel="noopener noreferrer"><code>docker pull wpscanteam/vulnerablewordpress</code></a></p>
+                            <p class="resource-item-description">Intentionally exposed WordPress stack for plugin and theme security drills.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/hmlio/vaas-cve-2014-6271/" target="_blank" rel="noopener noreferrer"><code>docker pull hmlio/vaas-cve-2014-6271</code></a></p>
+                            <p class="resource-item-description">Shellshock proof-of-concept service for demonstrating environment-variable command injection.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/hmlio/vaas-cve-2014-0160/" target="_blank" rel="noopener noreferrer"><code>docker pull hmlio/vaas-cve-2014-0160</code></a></p>
+                            <p class="resource-item-description">Heartbleed lab container exposing vulnerable OpenSSL for TLS memory disclosure exercises.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/opendns/security-ninjas/" target="_blank" rel="noopener noreferrer"><code>docker pull opendns/security-ninjas</code></a></p>
+                            <p class="resource-item-description">Cisco Security Ninjas curriculum packaged for rapid team enablement.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/noncetonic/archlinux-pentest-lxde" target="_blank" rel="noopener noreferrer"><code>docker pull noncetonic/archlinux-pentest-lxde</code></a></p>
+                            <p class="resource-item-description">Arch Linux pentest desktop complete with LXDE and common offensive utilities.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/diogomonica/docker-bench-security/" target="_blank" rel="noopener noreferrer"><code>docker pull diogomonica/docker-bench-security</code></a></p>
+                            <p class="resource-item-description">Docker Bench for Security automates CIS benchmark checks against container hosts.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/ismisepaul/securityshepherd/" target="_blank" rel="noopener noreferrer"><code>docker pull ismisepaul/securityshepherd</code></a></p>
+                            <p class="resource-item-description">Deploy OWASP Security Shepherd to train developers through progressive challenge tracks.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/danmx/docker-owasp-webgoat/" target="_blank" rel="noopener noreferrer"><code>docker pull danmx/docker-owasp-webgoat</code></a></p>
+                            <p class="resource-item-description">OWASP WebGoat packaged for quick lesson delivery on insecure coding practices.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://github.com/owasp/nodegoat#option-3---run-nodegoat-on-docker" target="_blank" rel="noopener noreferrer"><code>docker pull vulnerables/web-owasp-nodegoat</code></a></p>
+                            <p class="resource-item-description">NodeGoat intentionally vulnerable Node.js application for modern web exploitation training.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/citizenstig/nowasp/" target="_blank" rel="noopener noreferrer"><code>docker pull citizenstig/nowasp</code></a></p>
+                            <p class="resource-item-description">OWASP Mutillidae II lab featuring OWASP Top Ten misconfigurations and vulns.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://github.com/bkimminich/juice-shop#docker-container--" target="_blank" rel="noopener noreferrer"><code>docker pull bkimminich/juice-shop</code></a></p>
+                            <p class="resource-item-description">OWASP Juice Shop container for gamified web application security practice.</p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hub.docker.com/r/phocean/msf/" target="_blank" rel="noopener noreferrer"><code>docker pull phocean/msf</code></a></p>
+                            <p class="resource-item-description">Alternative Metasploit image maintained for streamlined offensive pipelines.</p>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Exploit &amp; Vulnerability Archives</h3>
+                <ul class="resource-list compact">
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://www.exploit-db.com/" target="_blank" rel="noopener noreferrer">Exploit Database</a></p>
+                            <p class="resource-item-description">Rapid7's community-maintained exploit archive and repository of proof-of-concept vulnerable software.</p>
+                        </div>
+                    </li>
+                </ul>
             </div>
         </section>
         <section class="cyber-panel">
-            <h2><i data-lucide="cpu"></i> Hardware &amp; Physical Assessment Gear</h2>
-            <p class="highlight">
-                Compact hardware implants and testing devices can help red-teamers evaluate defenses in real-world environments. Always obtain explicit authorization before deploying any of the equipment below.
-            </p>
-            <div class="grid" style="gap: 1.75rem;">
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 WiFi Pineapple</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A portable wireless auditing platform designed to help security teams identify rogue access points and run controlled man-in-the-middle simulations. Modern models support cloud management, modular payloads, and detailed reporting for authorized assessments.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://hak5.org/products/wifi-pineapple" target="_blank" rel="noopener noreferrer">
-                            <span>Official Product Page</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 USB Rubber Ducky</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A programmable keystroke injection tool that emulates a trusted USB keyboard. Security practitioners leverage it to demonstrate the impact of unattended workstations and to test endpoint defenses against rapid payload delivery.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://hak5.org/products/usb-rubber-ducky" target="_blank" rel="noopener noreferrer">
-                            <span>Learn More</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 Key Croc</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A network-enabled keylogging implant that bridges between a keyboard and computer. When deployed in sanctioned security engagements, it helps blue teams understand the risk posed by physical access and monitor for unauthorized keystrokes in controlled scenarios.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://hak5.org/products/key-croc" target="_blank" rel="noopener noreferrer">
-                            <span>Product Details</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Proxmark3</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        An advanced RFID/NFC research platform that supports sniffing, reading, emulation, and analysis of a broad range of tags. It is widely used in labs to evaluate physical access control systems, develop mitigation strategies, and train security personnel.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://proxmark.com/cart" target="_blank" rel="noopener noreferrer">
-                            <span>Proxmark3 Kits</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://github.com/RfidResearchGroup/proxmark3" target="_blank" rel="noopener noreferrer">
-                            <span>Open Source Firmware</span>
-                            <i data-lucide="github"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Flipper Zero</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A portable multi-tool for pentesters and hardware hackers featuring radio, RFID, infrared, and GPIO interfaces. Within authorized engagements, it serves as a Swiss Army knife for quick protocol reconnaissance and testing of embedded devices.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://flipperzero.one/" target="_blank" rel="noopener noreferrer">
-                            <span>Flipper Zero Site</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
+            <h2><i data-lucide="cpu"></i> Reverse Engineering Toolchain</h2>
+            <div class="resource-section">
+                <h3>Disassemblers &amp; Debuggers</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hex-rays.com/products/ida/" target="_blank" rel="noopener noreferrer">IDA</a></p><p class="resource-item-description">Multi-processor disassembler and debugger available for Windows, macOS, and Linux analysts.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.ollydbg.de/" target="_blank" rel="noopener noreferrer">OllyDbg</a></p><p class="resource-item-description">32-bit assembler-level debugger favored for rapid Windows binary triage.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/x64dbg/x64dbg" target="_blank" rel="noopener noreferrer">x64dbg</a></p><p class="resource-item-description">Open-source x86/x64 debugger with an extensible plugin architecture for Windows reversing.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/radare/radare2" target="_blank" rel="noopener noreferrer">radare2</a></p><p class="resource-item-description">Portable reversing framework providing disassembly, debugging, emulation, and scripting.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/joelpx/plasma" target="_blank" rel="noopener noreferrer">plasma</a></p><p class="resource-item-description">Interactive disassembler for x86/ARM/MIPS that generates readable pseudo-code.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/pfalcon/ScratchABit" target="_blank" rel="noopener noreferrer">ScratchABit</a></p><p class="resource-item-description">Retargetable disassembler with IDAPython-compatible plugin API ideal for customization.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/aquynh/capstone" target="_blank" rel="noopener noreferrer">Capstone</a></p><p class="resource-item-description">Lightweight multi-architecture disassembly engine embedding easily into pipelines.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://ghidra-sre.org/" target="_blank" rel="noopener noreferrer">Ghidra</a></p><p class="resource-item-description">NSA-developed suite providing disassembly, decompilation, scripting, and collaboration.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Decompilers</h3>
+                <div class="resource-subsection">
+                    <h4>JVM-based Languages</h4>
+                    <ul class="resource-list compact">
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/Storyyeller/Krakatau" target="_blank" rel="noopener noreferrer">Krakatau</a></p><p class="resource-item-description">High-fidelity Java bytecode decompiler handling Scala and Kotlin targets.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/java-decompiler/jd-gui" target="_blank" rel="noopener noreferrer">JD-GUI</a></p><p class="resource-item-description">Classic GUI decompiler for inspecting Java classes quickly.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler" target="_blank" rel="noopener noreferrer">Procyon</a></p><p class="resource-item-description">Robust Java decompiler particularly strong with modern language features.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/deathmarine/Luyten" target="_blank" rel="noopener noreferrer">Luyten</a></p><p class="resource-item-description">Swing-based front-end for Procyon delivering searchable, colorized output.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="http://varaneckas.com/jad/" target="_blank" rel="noopener noreferrer">JAD</a></p><p class="resource-item-description">Historic closed-source Java decompiler useful when matching legacy research.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/skylot/jadx" target="_blank" rel="noopener noreferrer">JADX</a></p><p class="resource-item-description">Android-focused decompiler converting DEX and APK content into readable Java.</p></div></li>
+                    </ul>
+                </div>
+                <div class="resource-subsection">
+                    <h4>.NET Toolchain</h4>
+                    <ul class="resource-list compact">
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.jetbrains.com/decompiler/" target="_blank" rel="noopener noreferrer">dotPeek</a></p><p class="resource-item-description">JetBrains .NET decompiler for browsing assemblies and generating source.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/icsharpcode/ILSpy/" target="_blank" rel="noopener noreferrer">ILSpy</a></p><p class="resource-item-description">Open-source .NET assembly browser and decompiler with active development.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/dnSpy/dnSpy" target="_blank" rel="noopener noreferrer">dnSpy</a></p><p class="resource-item-description">.NET debugger and assembly editor capable of on-the-fly patching.</p></div></li>
+                    </ul>
+                </div>
+                <div class="resource-subsection">
+                    <h4>Native Code</h4>
+                    <ul class="resource-list compact">
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hopperapp.com" target="_blank" rel="noopener noreferrer">Hopper</a></p><p class="resource-item-description">macOS/Linux disassembler and decompiler targeting 32/64-bit binaries.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/radareorg/cutter" target="_blank" rel="noopener noreferrer">cutter</a></p><p class="resource-item-description">Qt interface for radare2 combining graph view, debug, and decompiler modes.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/avast-tl/retdec" target="_blank" rel="noopener noreferrer">retdec</a></p><p class="resource-item-description">LLVM-based open-source decompiler for PE and ELF binaries.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/yegord/snowman" target="_blank" rel="noopener noreferrer">snowman</a></p><p class="resource-item-description">User-friendly native code decompiler producing C-like pseudocode.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hex-rays.com/products/decompiler/" target="_blank" rel="noopener noreferrer">Hex-Rays Decompiler</a></p><p class="resource-item-description">Commercial decompiler plugin for IDA supporting multiple architectures.</p></div></li>
+                    </ul>
+                </div>
+                <div class="resource-subsection">
+                    <h4>Python</h4>
+                    <ul class="resource-list compact">
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/rocky/python-uncompyle6" target="_blank" rel="noopener noreferrer">uncompyle6</a></p><p class="resource-item-description">Decompiler for over twenty CPython releases, great for legacy bytecode recovery.</p></div></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="resource-section">
+                <h3>Deobfuscation Utilities</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/0xd4d/de4dot" target="_blank" rel="noopener noreferrer">de4dot</a></p><p class="resource-item-description">.NET deobfuscator and unpacker supporting many commercial protectors.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/beautify-web/js-beautify" target="_blank" rel="noopener noreferrer">JS Beautifier</a></p><p class="resource-item-description">Prettify JavaScript, JSON, HTML, and CSS to aid manual analysis.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://jsnice.org/" target="_blank" rel="noopener noreferrer">JS Nice</a></p><p class="resource-item-description">Statistical variable renaming service to recover semantics from obfuscated JS.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Reverse Engineering Helpers</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/lorenzoongithub/nudge4j" target="_blank" rel="noopener noreferrer">nudge4j</a></p><p class="resource-item-description">Bridge JVM internals to a browser for interactive inspection.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/pxb1988/dex2jar" target="_blank" rel="noopener noreferrer">dex2jar</a></p><p class="resource-item-description">Convert Android DEX files into Java class files for downstream tooling.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://code.google.com/p/androguard/" target="_blank" rel="noopener noreferrer">androguard</a></p><p class="resource-item-description">Comprehensive Android reverse engineering and malware analysis framework.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/0xd4d/antinet" target="_blank" rel="noopener noreferrer">antinet</a></p><p class="resource-item-description">Anti-managed debugger/profiler utilities for .NET security research.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://upx.sourceforge.net/" target="_blank" rel="noopener noreferrer">UPX</a></p><p class="resource-item-description">Pack and unpack executables with the Ultimate Packer for eXecutables.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Execution Logging &amp; Tracing</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.wireshark.org/" target="_blank" rel="noopener noreferrer">Wireshark</a></p><p class="resource-item-description">Industry-standard packet analyzer for capturing and inspecting network conversations.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.tcpdump.org/" target="_blank" rel="noopener noreferrer">tcpdump</a></p><p class="resource-item-description">Command-line packet capture utility paired with the libpcap capture library.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/mitmproxy/mitmproxy" target="_blank" rel="noopener noreferrer">mitmproxy</a></p><p class="resource-item-description">Interactive man-in-the-middle proxy for inspecting and modifying HTTP/S traffic.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://charlesproxy.com" target="_blank" rel="noopener noreferrer">Charles Proxy</a></p><p class="resource-item-description">Cross-platform GUI proxy for viewing, rewinding, and exporting intercepted sessions.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.kernel.org/doc/Documentation/usb/usbmon.txt" target="_blank" rel="noopener noreferrer">usbmon</a></p><p class="resource-item-description">Linux USB bus monitor capturing control, bulk, interrupt, and isochronous transfers.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/desowin/usbpcap" target="_blank" rel="noopener noreferrer">USBPcap</a></p><p class="resource-item-description">Windows kernel driver and Wireshark plugin for USB traffic capture.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/ampotos/dynStruct" target="_blank" rel="noopener noreferrer">dynStruct</a></p><p class="resource-item-description">Recover in-memory structure layouts via dynamic instrumentation.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/mxmssh/drltrace" target="_blank" rel="noopener noreferrer">drltrace</a></p><p class="resource-item-description">Shared library call tracer built on DynamoRIO for Windows and Linux.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Binary Analysis &amp; Editing</h3>
+                <div class="resource-subsection">
+                    <h4>Hex Editors</h4>
+                    <ul class="resource-list compact">
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="http://mh-nexus.de/en/hxd/" target="_blank" rel="noopener noreferrer">HxD</a></p><p class="resource-item-description">Fast hex editor for raw disk editing and RAM inspection.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.winhex.com/winhex/" target="_blank" rel="noopener noreferrer">WinHex</a></p><p class="resource-item-description">Forensics-ready hex editor supporting data recovery and low-level processing.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/EUA/wxHexEditor" target="_blank" rel="noopener noreferrer">wxHexEditor</a></p><p class="resource-item-description">Open-source hex editor optimized for huge files and disks.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.synalysis.net/" target="_blank" rel="noopener noreferrer">Synalize It</a> / <a href="https://hexinator.com/" target="_blank" rel="noopener noreferrer">Hexinator</a></p><p class="resource-item-description">Grammar-based binary parsers for decoding proprietary file formats.</p></div></li>
+                    </ul>
+                </div>
+                <div class="resource-subsection">
+                    <h4>Binary Utilities</h4>
+                    <ul class="resource-list compact">
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/ReFirmLabs/binwalk" target="_blank" rel="noopener noreferrer">Binwalk</a></p><p class="resource-item-description">Firmware analysis toolkit detecting signatures, extracting archives, and visualizing entropy.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/codilime/veles" target="_blank" rel="noopener noreferrer">Veles</a></p><p class="resource-item-description">Statistical visualization platform for binary blobs and encryption research.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/kaitai-io/kaitai_struct" target="_blank" rel="noopener noreferrer">Kaitai Struct</a></p><p class="resource-item-description">DSL and IDE for describing binary formats and generating parsers.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/jmendeth/protobuf-inspector" target="_blank" rel="noopener noreferrer">Protobuf Inspector</a></p><p class="resource-item-description">Inspect and reverse-engineer Protocol Buffers payloads.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/ohjeongwook/DarunGrim" target="_blank" rel="noopener noreferrer">DarunGrim</a></p><p class="resource-item-description">Executable diffing solution to compare patched and unpatched binaries.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/dbeaver/dbeaver" target="_blank" rel="noopener noreferrer">DBeaver</a></p><p class="resource-item-description">Cross-platform database client handy when analyzing embedded data stores.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/lucasg/Dependencies" target="_blank" rel="noopener noreferrer">Dependencies</a></p><p class="resource-item-description">Modern replacement for Dependency Walker to map DLL relationships.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="http://wjradburn.com/software/" target="_blank" rel="noopener noreferrer">PEview</a></p><p class="resource-item-description">Inspect PE/COFF headers and sections within Windows executables.</p></div></li>
+                        <li><div class="resource-item"><p class="resource-item-title"><a href="https://web.archive.org/web/http://www.mcafee.com/kr/downloads/free-tools/bintext.aspx" target="_blank" rel="noopener noreferrer">BinText</a></p><p class="resource-item-description">Extract ASCII and Unicode strings from binaries for quick triage.</p></div></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="resource-section">
+                <h3>Malware Samples &amp; References</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.offensivecomputing.net/" target="_blank" rel="noopener noreferrer">Open Malware</a></p><p class="resource-item-description">Community-driven repository of malware samples for defensive research.</p></div></li>
+                </ul>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="globe"></i> Web &amp; Network Operations</h2>
+            <div class="resource-section">
+                <h3>Web Assessment Tools</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://spyse.com/" target="_blank" rel="noopener noreferrer">Spyse</a></p><p class="resource-item-description">OSINT search engine aggregating hosts, domains, SSL data, ports, and technologies.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/sqlmapproject/sqlmap" target="_blank" rel="noopener noreferrer">sqlmap</a></p><p class="resource-item-description">Automate SQL injection discovery and database takeover with tamper scripts.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/codingo/NoSQLMap" target="_blank" rel="noopener noreferrer">NoSQLMap</a></p><p class="resource-item-description">Enumerate and exploit NoSQL backends through injection and privilege abuse.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://tools.web-max.ca/encode_decode.php" target="_blank" rel="noopener noreferrer">Web-Max Encoders</a></p><p class="resource-item-description">Browser-based base64/base85 encoders plus MD4/MD5/SHA1 hashing helpers.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/codingo/VHostScan" target="_blank" rel="noopener noreferrer">VHostScan</a></p><p class="resource-item-description">Detect virtual host mappings, wildcard DNS, and aliasing for targeted pivoting.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/subfinder/subfinder" target="_blank" rel="noopener noreferrer">SubFinder</a></p><p class="resource-item-description">Passive subdomain enumeration using curated data sources and transformations.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://findsubdomains.com/" target="_blank" rel="noopener noreferrer">Findsubdomains</a></p><p class="resource-item-description">Hosted subdomain discovery service validating results across OSINT feeds.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/kpcyrd/badtouch" target="_blank" rel="noopener noreferrer">badtouch</a></p><p class="resource-item-description">Scriptable network authentication cracker tailored for custom attack flows.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/nil0x42/phpsploit" target="_blank" rel="noopener noreferrer">PhpSploit</a></p><p class="resource-item-description">Covert PHP-based C2 framework for maintaining footholds on compromised web servers.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/HightechSec/git-scanner" target="_blank" rel="noopener noreferrer">Git-Scanner</a></p><p class="resource-item-description">Identify publicly exposed .git directories and extract sensitive artifacts.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://cspscanner.com/" target="_blank" rel="noopener noreferrer">CSP Scanner</a></p><p class="resource-item-description">Analyze Content Security Policies for bypasses, missing directives, and weaknesses.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.shodan.io/" target="_blank" rel="noopener noreferrer">Shodan</a></p><p class="resource-item-description">Search engine for internet-connected devices, banner data, and exposed services.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/robertdavidgraham/masscan" target="_blank" rel="noopener noreferrer">masscan</a></p><p class="resource-item-description">Internet-scale port scanner capable of sweeping the IPv4 space rapidly.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/SpectralOps/keyscope" target="_blank" rel="noopener noreferrer">Keyscope</a></p><p class="resource-item-description">Validate leaked credentials and API keys across SaaS providers.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.decompiler.com/" target="_blank" rel="noopener noreferrer">Decompiler.com</a></p><p class="resource-item-description">Online decompiler supporting Java, Android, Python, and C# binaries.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Web Application Security References</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/jesusprubio/strong-node" target="_blank" rel="noopener noreferrer">Strong node.js</a></p><p class="resource-item-description">Checklist and guidelines for securing Node.js services during code reviews.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Network Reconnaissance &amp; Exploitation</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.netresec.com/?page=NetworkMiner" target="_blank" rel="noopener noreferrer">NetworkMiner</a></p><p class="resource-item-description">Network forensic analysis tool extracting hosts, sessions, files, and credentials.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://sourceforge.net/projects/paros/" target="_blank" rel="noopener noreferrer">Paros</a></p><p class="resource-item-description">Java-based HTTP/HTTPS proxy for active web application vulnerability testing.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/rafael-santiago/pig" target="_blank" rel="noopener noreferrer">pig</a></p><p class="resource-item-description">Linux packet crafting toolkit useful for fuzzing and replaying custom packets.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://findsubdomains.com" target="_blank" rel="noopener noreferrer">findsubdomains</a></p><p class="resource-item-description">High-speed subdomain discovery service supporting recon-scale inventories.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.cirt.dk/" target="_blank" rel="noopener noreferrer">cirt-fuzzer</a></p><p class="resource-item-description">Simple TCP/UDP protocol fuzzer for uncovering malformed input handling.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://aslookup.com/" target="_blank" rel="noopener noreferrer">ASlookup</a></p><p class="resource-item-description">Investigate autonomous systems, associated CIDR blocks, and organizational metadata.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project" target="_blank" rel="noopener noreferrer">OWASP ZAP</a></p><p class="resource-item-description">Integrated penetration testing proxy for mapping and attacking web applications.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/Akdeniz/mitmsocks4j" target="_blank" rel="noopener noreferrer">mitmsocks4j</a></p><p class="resource-item-description">Java-based man-in-the-middle SOCKS proxy capturing interactive sessions.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/jtesta/ssh-mitm" target="_blank" rel="noopener noreferrer">ssh-mitm</a></p><p class="resource-item-description">Intercept SSH/SFTP connections to log credentials and commands during authorized tests.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://nmap.org/" target="_blank" rel="noopener noreferrer">nmap</a></p><p class="resource-item-description">Swiss Army knife network scanner for host discovery, port mapping, and scripting.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.aircrack-ng.org/" target="_blank" rel="noopener noreferrer">Aircrack-ng</a></p><p class="resource-item-description">802.11 suite for packet capture, WEP/WPA cracking, and wireless security assessments.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/GouveaHeitor/nipe" target="_blank" rel="noopener noreferrer">Nipe</a></p><p class="resource-item-description">Route all host traffic through Tor to emulate anonymized adversary behavior.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/portantier/habu" target="_blank" rel="noopener noreferrer">Habu</a></p><p class="resource-item-description">Python hacking toolkit covering sniffing, spoofing, and discovery tasks.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://n0where.net/wifijammer/" target="_blank" rel="noopener noreferrer">Wifi Jammer</a></p><p class="resource-item-description">Demonstrate Wi-Fi denial-of-service scenarios during controlled exercises.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://codebutler.github.io/firesheep/" target="_blank" rel="noopener noreferrer">Firesheep</a></p><p class="resource-item-description">Classic HTTP session hijacker to illustrate the need for TLS everywhere.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/secdev/awesome-scapy" target="_blank" rel="noopener noreferrer">Scapy</a></p><p class="resource-item-description">Powerful Python library for crafting, sending, and dissecting packets.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/OWASP/Amass" target="_blank" rel="noopener noreferrer">Amass</a></p><p class="resource-item-description">Enumerate attack surfaces via scraping, brute forcing, alterations, and reverse DNS sweeps.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/kpcyrd/sniffglue" target="_blank" rel="noopener noreferrer">sniffglue</a></p><p class="resource-item-description">Secure multithreaded packet sniffer with modern TLS handling.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/spectralops/netz" target="_blank" rel="noopener noreferrer">Netz</a></p><p class="resource-item-description">Discover misconfigurations across the public internet using zgrab2 and supporting tools.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/rustscan/rustscan" target="_blank" rel="noopener noreferrer">RustScan</a></p><p class="resource-item-description">Lightning-fast port scanner that feeds discovered ports to nmap for deep enumeration.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/Warxim/petep" target="_blank" rel="noopener noreferrer">PETEP</a></p><p class="resource-item-description">Extensible TCP/UDP proxy with GUI and TLS support for traffic modification.</p></div></li>
+                </ul>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="shield"></i> Digital Forensics &amp; Cryptography</h2>
+            <div class="resource-section">
+                <h3>Digital Forensics Suites</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.sleuthkit.org/autopsy/" target="_blank" rel="noopener noreferrer">Autopsy</a></p><p class="resource-item-description">GUI for The Sleuth Kit enabling timeline analysis, carving, and reporting.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/sleuthkit/sleuthkit" target="_blank" rel="noopener noreferrer">sleuthkit</a></p><p class="resource-item-description">Command-line forensics toolkit providing low-level disk and filesystem parsing.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.guidancesoftware.com/products/Pages/encase-forensic/overview.aspx" target="_blank" rel="noopener noreferrer">EnCase</a></p><p class="resource-item-description">Commercial investigative suite used for incident response and legal-grade evidence.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://malzilla.sourceforge.net/" target="_blank" rel="noopener noreferrer">malzilla</a></p><p class="resource-item-description">Inspect malicious web content, decode obfuscated scripts, and extract payloads.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://servicos.dpf.gov.br/ferramentas/IPED/" target="_blank" rel="noopener noreferrer">IPED</a></p><p class="resource-item-description">Brazilian Federal Police digital evidence indexer and processor.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/orlikoski/CyLR" target="_blank" rel="noopener noreferrer">CyLR</a></p><p class="resource-item-description">Collects critical forensic artifacts from Windows systems for rapid triage.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.caine-live.net/" target="_blank" rel="noopener noreferrer">CAINE</a></p><p class="resource-item-description">Ubuntu-based live environment bundling a comprehensive forensics toolkit.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Cryptography &amp; Password Cracking Tools</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/hellman/xortool" target="_blank" rel="noopener noreferrer">xortool</a></p><p class="resource-item-description">Recover key size and plaintext from repeated-key XOR ciphertexts.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.openwall.com/john/" target="_blank" rel="noopener noreferrer">John the Ripper</a></p><p class="resource-item-description">Password cracking powerhouse with extensive hash type support.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.aircrack-ng.org/" target="_blank" rel="noopener noreferrer">Aircrack</a></p><p class="resource-item-description">Use captured Wi-Fi packets to audit WEP and WPA-PSK network security.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/ciphey/ciphey" target="_blank" rel="noopener noreferrer">Ciphey</a></p><p class="resource-item-description">AI-assisted automatic decryption engine for classic ciphers and encodings.</p></div></li>
+                </ul>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="workflow"></i> Post-Exploitation &amp; Knowledge Bases</h2>
+            <div class="resource-section">
+                <h3>Post-Exploitation Frameworks</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/EmpireProject/Empire" target="_blank" rel="noopener noreferrer">Empire</a></p><p class="resource-item-description">PowerShell and Python agent framework with flexible command and control.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/byt3bl33d3r/SILENTTRINITY" target="_blank" rel="noopener noreferrer">SILENTTRINITY</a></p><p class="resource-item-description">IronPython-powered post-exploitation project bypassing constrained PowerShell environments.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/PowerShellMafia/PowerSploit" target="_blank" rel="noopener noreferrer">PowerSploit</a></p><p class="resource-item-description">PowerShell offensive security modules for reconnaissance, exploitation, and persistence.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/Genetic-Malware/Ebowla" target="_blank" rel="noopener noreferrer">Ebowla</a></p><p class="resource-item-description">Generate payloads keyed to environmental attributes to evade replay on other systems.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Hardware &amp; Physical Assessment Gear</h3>
+                <ul class="resource-list">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://hak5.org/products/wifi-pineapple" target="_blank" rel="noopener noreferrer">Hak5 WiFi Pineapple</a></p><p class="resource-item-description">Portable wireless auditing platform with cloud management, payload ecosystem, and rich reporting.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://hak5.org/products/usb-rubber-ducky" target="_blank" rel="noopener noreferrer">Hak5 USB Rubber Ducky</a></p><p class="resource-item-description">Programmable keystroke injector demonstrating endpoint abuse from unattended workstations.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://hak5.org/products/key-croc" target="_blank" rel="noopener noreferrer">Hak5 Key Croc</a></p><p class="resource-item-description">Network-enabled keylogging implant useful for illustrating physical access risks.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://proxmark.com/cart" target="_blank" rel="noopener noreferrer">Proxmark3</a></p><p class="resource-item-description">RFID/NFC research platform supporting sniffing, cloning, and emulation of badge technologies.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/RfidResearchGroup/proxmark3" target="_blank" rel="noopener noreferrer">Proxmark3 Firmware</a></p><p class="resource-item-description">Open-source codebase powering Proxmark hardware deployments.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://flipperzero.one/" target="_blank" rel="noopener noreferrer">Flipper Zero</a></p><p class="resource-item-description">Multi-tool for pentesters featuring radio, RFID, infrared, and GPIO interfaces.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Security Knowledge Bases &amp; Inventories</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://sectools.org/" target="_blank" rel="noopener noreferrer">SecTools</a></p><p class="resource-item-description">Community-ranked index of the top 125 network security tools.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.roppers.org/courses/security" target="_blank" rel="noopener noreferrer">Roppers Security Fundamentals</a></p><p class="resource-item-description">Free course teaching security theory and defensive execution with full GitBook text.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.roppers.org/courses/networking" target="_blank" rel="noopener noreferrer">Roppers Practical Networking</a></p><p class="resource-item-description">Hands-on introduction to networking fundamentals and packet manipulation.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://inventory.raw.pm/" target="_blank" rel="noopener noreferrer">Rawsec's CyberSecurity Inventory</a></p><p class="resource-item-description">Open catalog of tools, operating systems, CTF platforms, and resources.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://cr0mll.github.io/cyberclopaedia/" target="_blank" rel="noopener noreferrer">The Cyberclopaedia</a></p><p class="resource-item-description">Open-source encyclopedia documenting cybersecurity concepts and tooling.</p></div></li>
+                </ul>
             </div>
         </section>
         <footer>

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -173,6 +173,129 @@ nav {
     height: 1rem;
 }
 
+.resource-section {
+    margin-top: 2rem;
+}
+
+.resource-section:first-of-type {
+    margin-top: 0;
+}
+
+.resource-section h3 {
+    margin: 0 0 1rem;
+    font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: rgba(204, 255, 204, 0.9);
+}
+
+.resource-subsection {
+    margin-top: 1.5rem;
+}
+
+.resource-subsection h4 {
+    margin: 0 0 0.75rem;
+    font-size: clamp(1.1rem, 1.9vw, 1.4rem);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: rgba(187, 255, 187, 0.85);
+}
+
+.resource-subsection h5 {
+    margin: 0.5rem 0;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: rgba(170, 255, 170, 0.8);
+}
+
+.resource-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.resource-list.compact {
+    gap: 0.75rem;
+}
+
+.resource-item {
+    border: 1px solid rgba(0, 255, 136, 0.25);
+    border-radius: 0.85rem;
+    padding: 1rem 1.25rem;
+    background: rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(4px);
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.resource-item:hover {
+    border-color: rgba(0, 255, 136, 0.5);
+    box-shadow: 0 0 18px rgba(0, 255, 136, 0.25);
+    transform: translateY(-2px);
+}
+
+.resource-item-title {
+    margin: 0;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 1.05rem;
+    letter-spacing: 0.03em;
+    color: rgba(204, 255, 204, 0.95);
+}
+
+.resource-item-title a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+}
+
+.resource-item-title a:hover {
+    color: var(--color-neon-primary);
+    border-bottom-color: rgba(0, 255, 136, 0.5);
+}
+
+.resource-item-description {
+    margin: 0.5rem 0 0;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.resource-item-links {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.resource-item-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(0, 255, 136, 0.35);
+    background: rgba(0, 0, 0, 0.2);
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
+}
+
+.resource-item-links a:hover {
+    border-color: var(--color-neon-primary);
+    box-shadow: 0 0 14px rgba(0, 255, 136, 0.35);
+    transform: translateY(-2px);
+}
+
+.resource-note {
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
 .font-mono {
     font-family: 'Roboto Mono', monospace;
 }

--- a/public/ethical-hacking-tutorials.html
+++ b/public/ethical-hacking-tutorials.html
@@ -30,101 +30,140 @@
             <a class="nav-link" data-nav-link data-page-target="contact" href="/contact.html"> <i data-lucide="mail"></i> Contact</a>
         </nav>
         <section class="cyber-panel" aria-labelledby="tutorials-heading">
-            <h2 id="tutorials-heading"><i data-lucide="book-open-check"></i> Ethical Hacking Tutorials</h2>
+            <h2 id="tutorials-heading"><i data-lucide="book-open-check"></i> Structured Learning Tracks</h2>
             <p class="highlight">
-                Build expertise the right way. Each track below combines trusted study material, hands-on labs, and professional certifications to reinforce lawful, defensible security practice. Pair them with the Analyst Chat console whenever you need clarification or a tailored learning plan.
+                Everything from <em>awesome-hacking</em>’s curriculum is indexed here—start with fundamentals, branch into reverse
+                engineering, and keep expanding with hands-on practice environments. Pair these with the Analyst Chat to craft a
+                personalized study plan.
             </p>
-            <div class="tutorial-grid">
-                <article class="data-card tutorial-card">
-                    <h3 class="font-mono">Foundations &amp; Certifications</h3>
-                    <div class="tutorial-meta">
-                        <i data-lucide="layers"></i>
-                        <span>Skill Floor</span>
-                    </div>
-                    <ul class="tutorial-topics">
-                        <li>Study CompTIA Security+ or Network+ to cement terminology, protocols, and defensive patterns.</li>
-                        <li>Follow TryHackMe's "Pre-Security" and "Jr Penetration Tester" learning paths for guided labs.</li>
-                        <li>Track progress with a personal runbook and collect write-ups for every lab completed.</li>
-                    </ul>
-                    <div class="tutorial-actions">
-                        <a class="resource-link" href="https://tryhackme.com/path/outline/presecurity" target="_blank" rel="noopener noreferrer">
-                            <span>TryHackMe Pre-Security</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://www.comptia.org/certifications/security" target="_blank" rel="noopener noreferrer">
-                            <span>CompTIA Security+</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card tutorial-card">
-                    <h3 class="font-mono">Hands-On Lab Operations</h3>
-                    <div class="tutorial-meta">
-                        <i data-lucide="target"></i>
-                        <span>Practice Ranges</span>
-                    </div>
-                    <ul class="tutorial-topics">
-                        <li>Spin up the OWASP Juice Shop or WebGoat locally to learn application security through deliberate exploitation.</li>
-                        <li>Enroll in Hack The Box Academy modules focused on enumeration, privilege escalation, and Active Directory.</li>
-                        <li>Document every attack chain, highlighting detection opportunities for blue teams.</li>
-                    </ul>
-                    <div class="tutorial-actions">
-                        <a class="resource-link" href="https://owasp.org/www-project-juice-shop/" target="_blank" rel="noopener noreferrer">
-                            <span>OWASP Juice Shop</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://academy.hackthebox.com/" target="_blank" rel="noopener noreferrer">
-                            <span>Hack The Box Academy</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card tutorial-card">
-                    <h3 class="font-mono">Defensive Countermeasures</h3>
-                    <div class="tutorial-meta">
-                        <i data-lucide="shield"></i>
-                        <span>Blue Team</span>
-                    </div>
-                    <ul class="tutorial-topics">
-                        <li>Complete the SANS Blue Team Operations exercises or the open Sigma rules workshops to sharpen detection engineering.</li>
-                        <li>Deploy the Elastic Security or Wazuh stack in a lab to practice log ingestion, correlation, and automated response.</li>
-                        <li>Use MITRE D3FEND to map remediations against observed ATT&amp;CK techniques.</li>
-                    </ul>
-                    <div class="tutorial-actions">
-                        <a class="resource-link" href="https://www.elastic.co/security-labs" target="_blank" rel="noopener noreferrer">
-                            <span>Elastic Security Labs</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://github.com/wazuh/wazuh" target="_blank" rel="noopener noreferrer">
-                            <span>Deploy Wazuh</span>
-                            <i data-lucide="github"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card tutorial-card">
-                    <h3 class="font-mono">Operational Playbooks</h3>
-                    <div class="tutorial-meta">
-                        <i data-lucide="book-marked"></i>
-                        <span>Process</span>
-                    </div>
-                    <ul class="tutorial-topics">
-                        <li>Study NIST SP 800-115 and 800-61 to understand formal testing methodology and incident handling.</li>
-                        <li>Build a repeatable rules-of-engagement template covering scope, escalation, and evidence handling.</li>
-                        <li>Review real-world post-incident reports and convert lessons learned into tabletop drills.</li>
-                    </ul>
-                    <div class="tutorial-actions">
-                        <a class="resource-link" href="https://csrc.nist.gov/publications/detail/sp/800-115/rev-1/draft" target="_blank" rel="noopener noreferrer">
-                            <span>NIST SP 800-115</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://www.mitre.org/impact/d3fend" target="_blank" rel="noopener noreferrer">
-                            <span>MITRE D3FEND</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
+            <div class="resource-section">
+                <h3>System Tutorials</h3>
+                <ul class="resource-list">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.roppers.org/courses/fundamentals" target="_blank" rel="noopener noreferrer">Roppers Computing Fundamentals</a></p><p class="resource-item-description">Self-paced curriculum covering computing and networking basics from zero experience to confident security learner. Full GitBook available for reference.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/" target="_blank" rel="noopener noreferrer">Corelan Exploit Writing Tutorials</a></p><p class="resource-item-description">Legendary series that teaches stack-based exploitation, SEH bypasses, and payload development in meticulous detail.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://web.archive.org/web/20140916085343/http://www.punter-infosec.com/exploit-writing-tutorials-for-pentesters/" target="_blank" rel="noopener noreferrer">Exploit Writing Tutorials for Pentesters</a></p><p class="resource-item-description">Archived walk-throughs focused on exploit building techniques tailored to penetration testers.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/r0hi7/BinExp" target="_blank" rel="noopener noreferrer">Understanding Linux Binary Exploitation</a></p><p class="resource-item-description">GitHub curriculum introducing ELF internals, shellcoding, and exploitation patterns on Linux.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J" target="_blank" rel="noopener noreferrer">Shells Playlist</a></p><p class="resource-item-description">Video playlist exploring interactive shells, payload delivery, and command execution techniques.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://missing.csail.mit.edu/2020/course-shell/" target="_blank" rel="noopener noreferrer">Missing Semester</a></p><p class="resource-item-description">MIT course that fills in command-line, shell, and tooling fundamentals crucial to efficient security work.</p></div></li>
+                </ul>
             </div>
-            <p class="legal-note" style="margin-top: 2rem;">Training resources are for authorized research and defense. Always respect privacy, terms of service, and local regulations.</p>
+            <div class="resource-section">
+                <h3>Reverse Engineering Tutorials</h3>
+                <ul class="resource-list">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.begin.re/the-workshop" target="_blank" rel="noopener noreferrer">Begin RE Workshop</a></p><p class="resource-item-description">Guided reverse engineering tutorial series with practical labs for budding analysts.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://fumalwareanalysis.blogspot.kr/p/malware-analysis-tutorials-reverse.html" target="_blank" rel="noopener noreferrer">Malware Analysis Tutorials</a></p><p class="resource-item-description">Comprehensive blog-based curriculum focusing on malware reversing methodologies.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://malwareunicorn.org/workshops/re101.html#0" target="_blank" rel="noopener noreferrer">Malware Unicorn RE101</a></p><p class="resource-item-description">Workshop that combines lecture and labs to teach foundational reversing skills.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://archive.org/details/lena151" target="_blank" rel="noopener noreferrer">Lena151: Reversing With Lena</a></p><p class="resource-item-description">Classic video series delivering progressive Windows cracking and reversing challenges.</p></div></li>
+                </ul>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="target"></i> Practice Arenas &amp; Wargames</h2>
+            <div class="resource-section">
+                <h3>System Challenges</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://overthewire.org/wargames/semtex/" target="_blank" rel="noopener noreferrer">OverTheWire: Semtex</a></p><p class="resource-item-description">Tackle progressively harder exploitation problems with a focus on binary mastery.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://overthewire.org/wargames/vortex/" target="_blank" rel="noopener noreferrer">OverTheWire: Vortex</a></p><p class="resource-item-description">Low-level Linux challenges emphasizing network programming and exploitation.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://overthewire.org/wargames/drifter/" target="_blank" rel="noopener noreferrer">OverTheWire: Drifter</a></p><p class="resource-item-description">Explore exploitation of binaries with network interaction and creative payloads.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://pwnable.kr/" target="_blank" rel="noopener noreferrer">pwnable.kr</a></p><p class="resource-item-description">Collection of system-level exploitation problems curated for aspiring pwners.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://exploit-exercises.com/nebula/" target="_blank" rel="noopener noreferrer">Exploit Exercises: Nebula</a></p><p class="resource-item-description">Virtual machine of Linux privilege escalation scenarios with guided write-ups.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://smashthestack.org/" target="_blank" rel="noopener noreferrer">SmashTheStack</a></p><p class="resource-item-description">Community-driven wargames covering stack smashing and other exploitation tactics.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hacking-lab.com/" target="_blank" rel="noopener noreferrer">HackingLab</a></p><p class="resource-item-description">Multi-disciplinary lab covering system, web, and crypto challenges with scoring.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Reverse Engineering Wargames</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.reversing.kr/" target="_blank" rel="noopener noreferrer">Reversing.kr</a></p><p class="resource-item-description">Challenge ladder that sharpens code reversing and crackme solving.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://codeengn.com/challenges/" target="_blank" rel="noopener noreferrer">CodeEngn Challenges</a></p><p class="resource-item-description">Korean-language reversing problems exploring anti-debugging and packing.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://simples.kr/" target="_blank" rel="noopener noreferrer">simples.kr</a></p><p class="resource-item-description">Additional Korean reversing missions ideal for cross-language practice.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://crackmes.de/" target="_blank" rel="noopener noreferrer">Crackmes.de</a></p><p class="resource-item-description">Historic archive of crackme binaries organized by difficulty.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Web &amp; Full-Stack Practice</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hackthissite.org/" target="_blank" rel="noopener noreferrer">Hack This Site!</a></p><p class="resource-item-description">Classic legal training ground with missions covering web, app, and programming puzzles.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hackthebox.com/" target="_blank" rel="noopener noreferrer">Hack The Box</a></p><p class="resource-item-description">Ever-expanding lab of Windows and Linux targets spanning pentest specialties.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://webhacking.kr/" target="_blank" rel="noopener noreferrer">Webhacking.kr</a></p><p class="resource-item-description">Korean challenge site focusing on web application exploitation skills.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://0xf.at/" target="_blank" rel="noopener noreferrer">0xf.at</a></p><p class="resource-item-description">Password riddles and hackits without logins—ideal for quick puzzles.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://fuzzy.land/" target="_blank" rel="noopener noreferrer">fuzzy.land</a></p><p class="resource-item-description">Austrian-hosted archive of CTF challenges ready for replay.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://google-gruyere.appspot.com/" target="_blank" rel="noopener noreferrer">Google Gruyere</a></p><p class="resource-item-description">Deliberately vulnerable web app illustrating cross-site scripting and injection issues.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.owasp.org/index.php/OWASP_Vulnerable_Web_Applications_Directory_Project#tab=On-Line_apps" target="_blank" rel="noopener noreferrer">OWASP Vulnerable Web Apps</a></p><p class="resource-item-description">Index of online applications purposely built for security training.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://tryhackme.com/" target="_blank" rel="noopener noreferrer">TryHackMe</a></p><p class="resource-item-description">Guided paths and virtual rooms covering web, cloud, and defensive tradecraft.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Cryptography Wargames</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://overthewire.org/wargames/krypton/" target="_blank" rel="noopener noreferrer">OverTheWire: Krypton</a></p><p class="resource-item-description">Incremental crypto wargame covering substitution ciphers, frequency analysis, and beyond.</p></div></li>
+                </ul>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="briefcase"></i> Bug Bounty &amp; Professional Opportunities</h2>
+            <div class="resource-section">
+                <h3>Knowledge Bases</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/EdOverflow/bugbounty-cheatsheet" target="_blank" rel="noopener noreferrer">Awesome Bug Bounty Resources</a></p><p class="resource-item-description">EdOverflow’s curated collection of recon workflows, report templates, and bounty tips.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Bug Bounty Platforms</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.bugcrowd.com/" target="_blank" rel="noopener noreferrer">Bugcrowd</a></p><p class="resource-item-description">Marketplace connecting researchers with public and private bounty programs.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hackerone.com/start-hacking" target="_blank" rel="noopener noreferrer">HackerOne</a></p><p class="resource-item-description">Industry-leading bug bounty and vulnerability coordination platform.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.intigriti.com/" target="_blank" rel="noopener noreferrer">Intigriti</a></p><p class="resource-item-description">European bug bounty hub offering recurring challenges and managed programs.</p></div></li>
+                </ul>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="trophy"></i> CTF Circuits &amp; Reference Hubs</h2>
+            <div class="resource-section">
+                <h3>Competitions</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://legitbs.net/" target="_blank" rel="noopener noreferrer">DEF CON CTF</a></p><p class="resource-item-description">Flagship capture-the-flag contest featuring offense, defense, and mixed rounds.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://ctf.isis.poly.edu/" target="_blank" rel="noopener noreferrer">CSAW CTF</a></p><p class="resource-item-description">Academic-focused competition run by NYU Tandon with global qualifiers.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://hack.lu/" target="_blank" rel="noopener noreferrer">hack.lu CTF</a></p><p class="resource-item-description">European event blending technical challenges with creative problem solving.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.plaidctf.com/" target="_blank" rel="noopener noreferrer">Plaid CTF</a></p><p class="resource-item-description">Plaid Parliament of Pwning’s competition known for elegant, tricky tasks.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://ructf.org/e/" target="_blank" rel="noopener noreferrer">RuCTFe</a></p><p class="resource-item-description">Russian Jeopardy-style contest with wide-ranging exploitation categories.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://ghostintheshellcode.com/" target="_blank" rel="noopener noreferrer">Ghost in the Shellcode</a></p><p class="resource-item-description">Team-based CTF emphasizing binary exploitation and creative puzzles.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.phdays.com/" target="_blank" rel="noopener noreferrer">PHD CTF</a></p><p class="resource-item-description">Positive Hack Days competition blending attack-defense and jeopardy rounds.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://secuinside.com/" target="_blank" rel="noopener noreferrer">SECUINSIDE CTF</a></p><p class="resource-item-description">Korean security conference CTF with unique exploitation tasks.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://ctf.codegate.org/html/Main.html?lang=eng" target="_blank" rel="noopener noreferrer">Codegate CTF</a></p><p class="resource-item-description">Long-running competition with qualifiers and finals in Seoul.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://bostonkeyparty.net/" target="_blank" rel="noopener noreferrer">Boston Key Party</a></p><p class="resource-item-description">CTF that prides itself on inventive, high-quality reverse engineering and crypto problems.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://zerodays.ie/" target="_blank" rel="noopener noreferrer">ZeroDays CTF</a></p><p class="resource-item-description">Irish security challenge with student and professional divisions.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://insomnihack.ch/" target="_blank" rel="noopener noreferrer">Insomni'hack</a></p><p class="resource-item-description">Swiss-held contest culminating at the Insomni'hack conference.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://picoctf.com/" target="_blank" rel="noopener noreferrer">picoCTF</a></p><p class="resource-item-description">Beginner-friendly competition created by Carnegie Mellon for students.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://prompt.ml/" target="_blank" rel="noopener noreferrer">prompt(1) to win</a></p><p class="resource-item-description">Series of XSS challenges crafted by the Google Security Team.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.hackthebox.com/" target="_blank" rel="noopener noreferrer">Hack The Box</a></p><p class="resource-item-description">In addition to labs, HTB hosts seasonal CTFs and ranked competitions.</p></div></li>
+                </ul>
+            </div>
+            <div class="resource-section">
+                <h3>Reference Hubs &amp; Media</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://hack.plus" target="_blank" rel="noopener noreferrer">Hack+</a></p><p class="resource-item-description">Bot-powered feed aggregating the latest InfoSec and CTF content.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://ctftime.org/" target="_blank" rel="noopener noreferrer">CTFtime.org</a></p><p class="resource-item-description">Global calendar, ratings, and write-ups for the entire CTF ecosystem.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://www.wechall.net/" target="_blank" rel="noopener noreferrer">WeChall</a></p><p class="resource-item-description">Meta-ranking site linking challenges across dozens of hacking platforms.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://shell-storm.org/repo/CTF/" target="_blank" rel="noopener noreferrer">CTF Archives @ shell-storm</a></p><p class="resource-item-description">Repository of past CTF tasks, binaries, and solutions.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://amzn.com/144962636X" target="_blank" rel="noopener noreferrer">Rootkit Arsenal</a></p><p class="resource-item-description">Book focused on operating system reverse engineering and rootkit development.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/coreb1t/awesome-pentest-cheat-sheets" target="_blank" rel="noopener noreferrer">Pentest Cheat Sheets</a></p><p class="resource-item-description">Collection of quick-reference guides for common offensive tasks.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/k4m4/movies-for-hackers" target="_blank" rel="noopener noreferrer">Movies for Hackers</a></p><p class="resource-item-description">Curated film list to keep the hacker culture inspiration alive.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://www.roppers.org/courses/ctf" target="_blank" rel="noopener noreferrer">Roppers CTF Fundamentals Course</a></p><p class="resource-item-description">Free course that trains the mindset and skills required to excel in crypto, forensics, and more.</p></div></li>
+                </ul>
+            </div>
+        </section>
+        <section class="cyber-panel">
+            <h2><i data-lucide="server"></i> Security-Focused Operating Systems</h2>
+            <div class="resource-section">
+                <h3>Research Directories</h3>
+                <ul class="resource-list compact">
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://inventory.raw.pm/operating_systems.html" target="_blank" rel="noopener noreferrer">Rawsec Security OS Inventory</a></p><p class="resource-item-description">Exhaustive list of security-oriented operating systems for labs and production.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://n0where.net/best-linux-penetration-testing-distributions/" target="_blank" rel="noopener noreferrer">CyberPunk: Best Linux PenTest Distros</a></p><p class="resource-item-description">Comparative overview of leading penetration-testing Linux distributions.</p></div></li>
+                    <li><div class="resource-item"><p class="resource-item-title"><a href="http://distrowatch.com/search.php?category=Security" target="_blank" rel="noopener noreferrer">DistroWatch Security Search</a></p><p class="resource-item-description">Searchable index of security-centric distributions with release tracking.</p></div></li>
+                </ul>
+                <p class="resource-note">Always obtain written authorization before deploying offensive operating systems on production networks.</p>
+            </div>
         </section>
         <footer>
             <div class="socials">


### PR DESCRIPTION
## Summary
- rebuild the Arsenal page into themed sections covering system platforms, dockerized labs, reverse engineering, web and network tooling, forensics, cryptography, post-exploitation, and knowledge bases from the awesome-hacking list
- expand the Tutorials experience with structured study tracks, wargames, bug bounty references, CTF circuits, and security OS directories derived from awesome-hacking resources
- add shared styling for the new resource lists and subsections to keep the expanded catalog readable across pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3863453f48327a14e9e94f4f8f9fe