### PR TITLE
Restore Arsenal external link styling

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -329,7 +329,8 @@ body.readable-mode .data-card:hover {
     transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
 }
 
-.resource-item:hover {
+.resource-item:hover,
+.resource-item:focus-within {
     border-color: rgba(0, 255, 136, 0.5);
     box-shadow: 0 0 18px rgba(0, 255, 136, 0.25);
     transform: translateY(-2px);
@@ -341,7 +342,8 @@ body.readable-mode .resource-item {
     box-shadow: none;
 }
 
-body.readable-mode .resource-item:hover {
+body.readable-mode .resource-item:hover,
+body.readable-mode .resource-item:focus-within {
     border-color: rgba(59, 130, 246, 0.5);
     box-shadow: 0 0 16px rgba(59, 130, 246, 0.2);
 }
@@ -355,14 +357,42 @@ body.readable-mode .resource-item:hover {
 }
 
 .resource-item-title a {
-    color: inherit;
-    text-decoration: none;
-    border-bottom: 1px solid transparent;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--color-neon-primary);
+    text-decoration: underline;
+    text-decoration-color: rgba(0, 255, 136, 0.45);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.35rem;
+    border-bottom: none;
+    transition: color 0.3s ease, text-decoration-color 0.3s ease;
 }
 
-.resource-item-title a:hover {
+.resource-item-title a::after {
+    content: '↗';
+    font-size: 0.75em;
+    opacity: 0.75;
+    transform: translate(0, 0);
+    transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.resource-item-title a:hover,
+.resource-item-title a:focus-visible {
     color: var(--color-neon-primary);
-    border-bottom-color: rgba(0, 255, 136, 0.5);
+    text-decoration-color: rgba(0, 255, 136, 0.75);
+}
+
+.resource-item-title a:hover::after,
+.resource-item-title a:focus-visible::after {
+    opacity: 1;
+    transform: translate(2px, -2px);
+}
+
+.resource-item-title a:focus-visible {
+    outline: 2px solid rgba(0, 255, 136, 0.6);
+    outline-offset: 4px;
+    border-radius: 0.4rem;
 }
 
 .resource-item-description {
@@ -405,6 +435,29 @@ body.readable-mode .resource-link {
     background: rgba(30, 41, 59, 0.8);
     border-color: var(--color-readable-border);
     color: var(--color-readable-text);
+}
+
+body.readable-mode .resource-item-title a {
+    color: var(--color-readable-accent);
+    text-decoration-color: rgba(59, 130, 246, 0.5);
+}
+
+body.readable-mode .resource-item-title a:hover,
+body.readable-mode .resource-item-title a:focus-visible {
+    text-decoration-color: rgba(59, 130, 246, 0.75);
+}
+
+body.readable-mode .resource-item-title a::after {
+    opacity: 0.65;
+}
+
+body.readable-mode .resource-item-title a:hover::after,
+body.readable-mode .resource-item-title a:focus-visible::after {
+    opacity: 1;
+}
+
+body.readable-mode .resource-item-title a:focus-visible {
+    outline-color: rgba(59, 130, 246, 0.6);
 }
 
 body.readable-mode .resource-item-links a:hover,


### PR DESCRIPTION
## Summary
- highlight Arsenal resource cards on hover and keyboard focus to reinforce interactivity
- restyle resource title links with neon underlines and an external-link indicator so the destinations are obvious again
- align the accessible mode color palette with the refreshed link styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3b19449b883278ed0f15ee7f9fbe9