### PR TITLE
Restore detailed hardware gear section in arsenal

### DIFF
--- a/public/arsenal.html
+++ b/public/arsenal.html
@@ -475,13 +475,63 @@
             </div>
             <div class="resource-section">
                 <h3>Hardware &amp; Physical Assessment Gear</h3>
+                <p class="highlight">
+                    Compact hardware implants and testing devices can help red-teamers evaluate defenses in real-world
+                    environments. Always obtain explicit authorization before deploying any of the equipment below.
+                </p>
                 <ul class="resource-list">
-                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://hak5.org/products/wifi-pineapple" target="_blank" rel="noopener noreferrer">Hak5 WiFi Pineapple</a></p><p class="resource-item-description">Portable wireless auditing platform with cloud management, payload ecosystem, and rich reporting.</p></div></li>
-                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://hak5.org/products/usb-rubber-ducky" target="_blank" rel="noopener noreferrer">Hak5 USB Rubber Ducky</a></p><p class="resource-item-description">Programmable keystroke injector demonstrating endpoint abuse from unattended workstations.</p></div></li>
-                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://hak5.org/products/key-croc" target="_blank" rel="noopener noreferrer">Hak5 Key Croc</a></p><p class="resource-item-description">Network-enabled keylogging implant useful for illustrating physical access risks.</p></div></li>
-                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://proxmark.com/cart" target="_blank" rel="noopener noreferrer">Proxmark3</a></p><p class="resource-item-description">RFID/NFC research platform supporting sniffing, cloning, and emulation of badge technologies.</p></div></li>
-                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://github.com/RfidResearchGroup/proxmark3" target="_blank" rel="noopener noreferrer">Proxmark3 Firmware</a></p><p class="resource-item-description">Open-source codebase powering Proxmark hardware deployments.</p></div></li>
-                    <li><div class="resource-item"><p class="resource-item-title"><a href="https://flipperzero.one/" target="_blank" rel="noopener noreferrer">Flipper Zero</a></p><p class="resource-item-description">Multi-tool for pentesters featuring radio, RFID, infrared, and GPIO interfaces.</p></div></li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hak5.org/products/wifi-pineapple" target="_blank" rel="noopener noreferrer">Hak5 WiFi Pineapple</a></p>
+                            <p class="resource-item-description">
+                                Portable wireless auditing platform built to surface rogue access points and conduct controlled
+                                man-in-the-middle simulations. Modern models support cloud management, modular payloads, and
+                                detailed reporting for sanctioned assessments.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hak5.org/products/usb-rubber-ducky" target="_blank" rel="noopener noreferrer">Hak5 USB Rubber Ducky</a></p>
+                            <p class="resource-item-description">
+                                Programmable keystroke injection tool that emulates a trusted USB keyboard. Red and blue teams
+                                rely on it to demonstrate the risk of unattended workstations and validate endpoint defenses
+                                against rapid payload delivery.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://hak5.org/products/key-croc" target="_blank" rel="noopener noreferrer">Hak5 Key Croc</a></p>
+                            <p class="resource-item-description">
+                                Network-enabled keylogging implant that bridges between a keyboard and host system. Within
+                                authorized exercises it highlights physical access exposure and captures keystrokes for
+                                defensive tuning.
+                            </p>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://proxmark.com/cart" target="_blank" rel="noopener noreferrer">Proxmark3</a></p>
+                            <p class="resource-item-description">
+                                Advanced RFID/NFC research platform supporting sniffing, cloning, and emulation across common
+                                badge technologies to help teams stress-test physical access controls.
+                            </p>
+                            <div class="resource-item-links">
+                                <a href="https://proxmark.com/cart" target="_blank" rel="noopener noreferrer">Proxmark3 Kits</a>
+                                <a href="https://github.com/RfidResearchGroup/proxmark3" target="_blank" rel="noopener noreferrer">Open Source Firmware</a>
+                            </div>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="resource-item">
+                            <p class="resource-item-title"><a href="https://flipperzero.one/" target="_blank" rel="noopener noreferrer">Flipper Zero</a></p>
+                            <p class="resource-item-description">
+                                Portable multi-tool for hardware hackers featuring sub-GHz radio, RFID, infrared, and GPIO
+                                interfaces. Ideal for quick reconnaissance of embedded targets during lab and field engagements.
+                            </p>
+                        </div>
+                    </li>
                 </ul>
             </div>
             <div class="resource-section">
@@ -493,78 +543,6 @@
                     <li><div class="resource-item"><p class="resource-item-title"><a href="https://inventory.raw.pm/" target="_blank" rel="noopener noreferrer">Rawsec's CyberSecurity Inventory</a></p><p class="resource-item-description">Open catalog of tools, operating systems, CTF platforms, and resources.</p></div></li>
                     <li><div class="resource-item"><p class="resource-item-title"><a href="https://cr0mll.github.io/cyberclopaedia/" target="_blank" rel="noopener noreferrer">The Cyberclopaedia</a></p><p class="resource-item-description">Open-source encyclopedia documenting cybersecurity concepts and tooling.</p></div></li>
                 </ul>
-            </div>
-        </section>
-        <section class="cyber-panel">
-            <h2><i data-lucide="cpu"></i> Hardware &amp; Physical Assessment Gear</h2>
-            <p class="highlight">
-                Compact hardware implants and testing devices can help red-teamers evaluate defenses in real-world environments. Always obtain explicit authorization before deploying any of the equipment below.
-            </p>
-            <div class="grid" style="gap: 1.75rem;">
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 WiFi Pineapple</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A portable wireless auditing platform designed to help security teams identify rogue access points and run controlled man-in-the-middle simulations. Modern models support cloud management, modular payloads, and detailed reporting for authorized assessments.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://hak5.org/products/wifi-pineapple" target="_blank" rel="noopener noreferrer">
-                            <span>Official Product Page</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 USB Rubber Ducky</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A programmable keystroke injection tool that emulates a trusted USB keyboard. Security practitioners leverage it to demonstrate the impact of unattended workstations and to test endpoint defenses against rapid payload delivery.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://hak5.org/products/usb-rubber-ducky" target="_blank" rel="noopener noreferrer">
-                            <span>Learn More</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Hak5 Key Croc</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A network-enabled keylogging implant that bridges between a keyboard and computer. When deployed in sanctioned security engagements, it helps blue teams understand the risk posed by physical access and monitor for unauthorized keystrokes in controlled scenarios.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://hak5.org/products/key-croc" target="_blank" rel="noopener noreferrer">
-                            <span>Product Details</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Proxmark3</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        An advanced RFID/NFC research platform that supports sniffing, reading, emulation, and analysis of a broad range of tags. It is widely used in labs to evaluate physical access control systems, develop mitigation strategies, and train security personnel.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://proxmark.com/cart" target="_blank" rel="noopener noreferrer">
-                            <span>Proxmark3 Kits</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                        <a class="resource-link" href="https://github.com/RfidResearchGroup/proxmark3" target="_blank" rel="noopener noreferrer">
-                            <span>Open Source Firmware</span>
-                            <i data-lucide="github"></i>
-                        </a>
-                    </div>
-                </article>
-                <article class="data-card">
-                    <p class="font-mono" style="font-size: 1.35rem; color: rgba(204,255,204,0.95);">Flipper Zero</p>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">
-                        A portable multi-tool for pentesters and hardware hackers featuring radio, RFID, infrared, and GPIO interfaces. Within authorized engagements, it serves as a Swiss Army knife for quick protocol reconnaissance and testing of embedded devices.
-                    </p>
-                    <div class="resource-actions">
-                        <a class="resource-link" href="https://flipperzero.one/" target="_blank" rel="noopener noreferrer">
-                            <span>Flipper Zero Site</span>
-                            <i data-lucide="external-link"></i>
-                        </a>
-                    </div>
-                </article>
             </div>
         </section>
         <footer>


### PR DESCRIPTION
## Summary
- reinstate the dedicated hardware & physical assessment guidance inside the resource-based arsenal layout
- enrich each hardware entry with the original detailed descriptions and supporting links while avoiding duplicate sections

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4a88652788327adc3f65d75e09681