### PR TITLE
Replace hardcoded Cloudflare credentials with placeholders

### DIFF
--- a/functions/api/briefing.js
+++ b/functions/api/briefing.js
@@ -1,5 +1,6 @@
-const DEFAULT_ACCOUNT_ID = 'e8823131dce5e3dcaedec59bb4f7c093';
-const DEFAULT_API_TOKEN = 'c1V6ar1TIEW8Qju2TYNIoHUgmrF079EhCSK0sL9M';
+// Placeholders ensure deployments provide explicit credentials via environment variables.
+const DEFAULT_ACCOUNT_ID = 'demo-account-id';
+const DEFAULT_API_TOKEN = 'demo-api-token';
 
 export async function onRequestGet(context) {
     const { env, request, waitUntil } = context;

--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -6,8 +6,9 @@ const DEFAULT_SYSTEM_PROMPT = [
 ].join(' ');
 
 const DEFAULT_MODEL = '@cf/meta/llama-3-8b-instruct';
-const DEFAULT_ACCOUNT_ID = 'e8823131dce5e3dcaedec59bb4f7c093';
-const DEFAULT_API_TOKEN = 'c1V6ar1TIEW8Qju2TYNIoHUgmrF079EhCSK0sL9M';
+// Intentionally non-functional placeholders so real credentials must be supplied via env vars.
+const DEFAULT_ACCOUNT_ID = 'demo-account-id';
+const DEFAULT_API_TOKEN = 'demo-api-token';
 const CORS_HEADERS = Object.freeze({
     'content-type': 'application/json',
     'access-control-allow-origin': '*',

--- a/tests/briefing.test.js
+++ b/tests/briefing.test.js
@@ -112,7 +112,7 @@ test('onRequestGet uses default credentials when missing', async () => {
     assert.equal(payload.markdown, '### Recent Data Breaches\n* fallback detail');
     assert.equal(
         calls[0][0],
-        'https://api.cloudflare.com/client/v4/accounts/e8823131dce5e3dcaedec59bb4f7c093/ai/run/@cf/meta/llama-3-8b-instruct'
+        'https://api.cloudflare.com/client/v4/accounts/demo-account-id/ai/run/@cf/meta/llama-3-8b-instruct'
     );
-    assert.equal(calls[0][1].headers.Authorization, 'Bearer c1V6ar1TIEW8Qju2TYNIoHUgmrF079EhCSK0sL9M');
+    assert.equal(calls[0][1].headers.Authorization, 'Bearer demo-api-token');
 });

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -114,9 +114,9 @@ test('onRequestPost falls back to default credentials when missing', async () =>
     assert.equal(calls.length, 1);
     assert.equal(
         calls[0].input,
-        'https://api.cloudflare.com/client/v4/accounts/e8823131dce5e3dcaedec59bb4f7c093/ai/run/@cf/meta/llama-3-8b-instruct'
+        'https://api.cloudflare.com/client/v4/accounts/demo-account-id/ai/run/@cf/meta/llama-3-8b-instruct'
     );
-    assert.equal(calls[0].init.headers.Authorization, 'Bearer c1V6ar1TIEW8Qju2TYNIoHUgmrF079EhCSK0sL9M');
+    assert.equal(calls[0].init.headers.Authorization, 'Bearer demo-api-token');
 });
 
 test('onRequestPost surfaces upstream AI error details', async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
 name = "hacktech"
-account_id = "e8823131dce5e3dcaedec59bb4f7c093"
+account_id = "00000000000000000000000000000000"
 pages_build_output_dir = "./public"
 compatibility_date = "2024-07-01"


### PR DESCRIPTION
## Summary
- replace the hardcoded Cloudflare account ID and API token defaults in the chat and briefing handlers with safe placeholders that require real credentials to come from the environment
- update the unit tests to assert against the new placeholder values and keep the expected behaviour intact
- swap the Wrangler configuration to use a non-sensitive placeholder account identifier

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4dcbf5bec8327a151b4c45eb5ee42