### PR TITLE
Switch Cloudflare AI calls to Gateway endpoints

### DIFF
--- a/functions/api/briefing.js
+++ b/functions/api/briefing.js
@@ -1,6 +1,32 @@
 // Placeholders ensure deployments provide explicit credentials via environment variables.
 const DEFAULT_ACCOUNT_ID = 'demo-account-id';
 const DEFAULT_API_TOKEN = 'demo-api-token';
+const DEFAULT_GATEWAY = 'demo-gateway';
+const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct';
+
+function resolveBriefingEndpoint(env, accountId) {
+    const model = (env.CLOUDFLARE_AI_MODEL || '').trim() || DEFAULT_MODEL;
+    const baseUrl = (env.CLOUDFLARE_AI_BASE_URL || '').trim();
+    const gatewaySlug = (env.CLOUDFLARE_AI_GATEWAY || '').trim();
+
+    if (!baseUrl) {
+        const normalizedGateway = (gatewaySlug || DEFAULT_GATEWAY).replace(/^\/+|\/+$/g, '');
+        const normalizedModel = model.replace(/^\/+/, '');
+        return `https://gateway.ai.cloudflare.com/v1/${accountId}/${normalizedGateway}/workers-ai/${normalizedModel}`;
+    }
+
+    const normalizedModel = model.replace(/^\//, '');
+
+    try {
+        const parsed = new URL(baseUrl);
+        if (!parsed.pathname.endsWith('/')) {
+            parsed.pathname = `${parsed.pathname}/`;
+        }
+        return `${parsed.toString()}${normalizedModel}`;
+    } catch (error) {
+        throw new Error('CLOUDFLARE_AI_BASE_URL must be a valid absolute URL.');
+    }
+}
 
 export async function onRequestGet(context) {
     const { env, request, waitUntil } = context;
@@ -31,22 +57,20 @@ export async function onRequestGet(context) {
     const userPrompt = `Summarize today\'s most significant cybersecurity developments. Include:\n\n1. One major, publicly disclosed data breach.\n2. One new or updated tool relevant to ethical hacking or defense.\n3. One significant update to a major security operating system like Kali Linux or Parrot OS.\n\nFormat the response with headings for "Recent Data Breaches", "New Tools & Exploits", and "Platform Updates".`;
 
     try {
-        const aiResponse = await fetch(
-            `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/@cf/meta/llama-3-8b-instruct`,
-            {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${apiToken}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    messages: [
-                        { role: 'system', content: systemPrompt },
-                        { role: 'user', content: userPrompt },
-                    ],
-                }),
-            }
-        );
+        const endpoint = resolveBriefingEndpoint(env, accountId);
+        const aiResponse = await fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                messages: [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'user', content: userPrompt },
+                ],
+            }),
+        });
 
         if (!aiResponse.ok) {
             const errorText = await aiResponse.text();

--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -5,7 +5,8 @@ const DEFAULT_SYSTEM_PROMPT = [
     'Use paragraphs or concise lists rather than markdown headings.',
 ].join(' ');
 
-const DEFAULT_MODEL = '@cf/meta/llama-3-8b-instruct';
+const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct';
+const DEFAULT_GATEWAY = 'demo-gateway';
 // Intentionally non-functional placeholders so real credentials must be supplied via env vars.
 const DEFAULT_ACCOUNT_ID = 'demo-account-id';
 const DEFAULT_API_TOKEN = 'demo-api-token';
@@ -60,9 +61,12 @@ function sanitizeMessages(rawMessages) {
 function resolveModelEndpoint(env, accountId) {
     const model = (env.CLOUDFLARE_AI_MODEL || '').trim() || DEFAULT_MODEL;
     const baseUrl = (env.CLOUDFLARE_AI_BASE_URL || '').trim();
+    const gatewaySlug = (env.CLOUDFLARE_AI_GATEWAY || '').trim();
 
     if (!baseUrl) {
-        return `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model.replace(/^\//, '')}`;
+        const normalizedGateway = (gatewaySlug || DEFAULT_GATEWAY).replace(/^\/+|\/+$/g, '');
+        const normalizedModel = model.replace(/^\/+/, '');
+        return `https://gateway.ai.cloudflare.com/v1/${accountId}/${normalizedGateway}/workers-ai/${normalizedModel}`;
     }
 
     try {

--- a/tests/briefing.test.js
+++ b/tests/briefing.test.js
@@ -61,7 +61,7 @@ test('onRequestGet returns AI response payload and caches the result', async () 
     };
 
     const context = {
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
+        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token', CLOUDFLARE_AI_GATEWAY: 'intel-gateway' },
         request: new Request('https://example.com/api/briefing'),
         waitUntil(promise) {
             waitUntilPromises.push(promise);
@@ -84,6 +84,11 @@ test('onRequestGet returns AI response payload and caches the result', async () 
     const secondResponse = await onRequestGet({ ...context, waitUntil: () => {} });
     assert.equal(fetchCalls.length, 1, 'AI fetch should only happen once');
     assert.equal((await secondResponse.clone().json()).markdown, body.markdown);
+
+    assert.equal(
+        fetchCalls[0][0],
+        'https://gateway.ai.cloudflare.com/v1/acct/intel-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
+    );
 });
 
 test('onRequestGet uses default credentials when missing', async () => {
@@ -112,7 +117,7 @@ test('onRequestGet uses default credentials when missing', async () => {
     assert.equal(payload.markdown, '### Recent Data Breaches\n* fallback detail');
     assert.equal(
         calls[0][0],
-        'https://api.cloudflare.com/client/v4/accounts/demo-account-id/ai/run/@cf/meta/llama-3-8b-instruct'
+        'https://gateway.ai.cloudflare.com/v1/demo-account-id/demo-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
     );
     assert.equal(calls[0][1].headers.Authorization, 'Bearer demo-api-token');
 });

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -51,7 +51,7 @@ test('onRequestPost forwards chat history and returns analyst reply', async () =
     });
 
     const response = await onRequestPost({
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
+        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token', CLOUDFLARE_AI_GATEWAY: 'my-gateway' },
         request,
     });
 
@@ -64,7 +64,10 @@ test('onRequestPost forwards chat history and returns analyst reply', async () =
     assert.equal(forwarded.messages[0].role, 'system');
     assert.equal(forwarded.messages[1].role, 'user');
     assert.equal(forwarded.messages[2].role, 'assistant');
-    assert.equal(requests[0].input, 'https://api.cloudflare.com/client/v4/accounts/acct/ai/run/@cf/meta/llama-3-8b-instruct');
+    assert.equal(
+        requests[0].input,
+        'https://gateway.ai.cloudflare.com/v1/acct/my-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
+    );
 });
 
 test('onRequestPost rejects invalid payloads', async () => {
@@ -114,7 +117,7 @@ test('onRequestPost falls back to default credentials when missing', async () =>
     assert.equal(calls.length, 1);
     assert.equal(
         calls[0].input,
-        'https://api.cloudflare.com/client/v4/accounts/demo-account-id/ai/run/@cf/meta/llama-3-8b-instruct'
+        'https://gateway.ai.cloudflare.com/v1/demo-account-id/demo-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
     );
     assert.equal(calls[0].init.headers.Authorization, 'Bearer demo-api-token');
 });
@@ -221,13 +224,16 @@ test('onRequestPost supports custom model endpoint configuration', async () => {
         env: {
             CLOUDFLARE_ACCOUNT_ID: 'acct',
             CLOUDFLARE_AI_TOKEN: 'token',
-            CLOUDFLARE_AI_BASE_URL: 'https://gateway.ai.cloudflare.com/v1/acct/gateway',
-            CLOUDFLARE_AI_MODEL: '@cf/meta/llama-3-8b-instruct',
+            CLOUDFLARE_AI_BASE_URL: 'https://gateway.ai.cloudflare.com/v1/acct/gateway/workers-ai',
+            CLOUDFLARE_AI_MODEL: '@cf/meta/llama-3.1-8b-instruct',
         },
         request,
     });
 
-    assert.equal(requests[0].input, 'https://gateway.ai.cloudflare.com/v1/acct/gateway/@cf/meta/llama-3-8b-instruct');
+    assert.equal(
+        requests[0].input,
+        'https://gateway.ai.cloudflare.com/v1/acct/gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
+    );
 });
 
 test('onRequestPost extracts replies from OpenAI-style choices arrays', async () => {


### PR DESCRIPTION
## Summary
- update the chat and briefing Workers to build Cloudflare AI requests against the Gateway endpoint and newer model
- add gateway-aware endpoint resolution that still supports custom base URLs
- refresh unit tests to assert the new defaults and configuration paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5d4e5a7d8832787ecfe0042aa6b48