### PR TITLE
Align Cloudflare AI integration with new gateway endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ I break things (legally) so you don’t get broken into. I deliver **clear, repr
 ---
 
 ## Methodology (Standards-Aligned)
-- **Scoping & Threat Modeling:** assets, data flows, abuse cases, impact map  
-- **Recon & Mapping:** OSINT, content discovery, API enumerations, attack surface diff  
+- **Scoping & Threat Modeling:** assets, data flows, abuse cases, impact map
+- **Recon & Mapping:** OSINT, content discovery, API enumerations, attack surface diff
 - **Exploitation:** safe PoCs, **no destructive payloads**; chain to business impact  
 - **Post-Exploitation:** data access proof, least-privilege escalation checks  
-- **Reporting:** CVSS/CWEs, reproducible steps, screenshots, **fix-first guidance**  
+- **Reporting:** CVSS/CWEs, reproducible steps, screenshots, **fix-first guidance**
 - **Validation:** retest window + remediation verification
 
 > References: PTES · OWASP WSTG/MASVS/MSTG · NIST 800-115 · OSSTMM
@@ -43,10 +43,10 @@ I break things (legally) so you don’t get broken into. I deliver **clear, repr
 ---
 
 ## Tooling (Representative)
-`Burp Suite Pro` · `ffuf` · `httpx` · `nuclei` · `kxss` · `gf` · `waybackurls` · `amass` · `Subfinder`  
-`Mitmproxy` · `Frida` · `objection` · `jadx` · `apktool` · `radare2`  
-`BloodHound` · `SharpHound` · `CrackMapExec` · `Rubeus`  
-Cloud: `prowler` · `ScoutSuite` · `CloudFox` · IaC checks (`tfsec`, `checkov`)  
+`Burp Suite Pro` · `ffuf` · `httpx` · `nuclei` · `kxss` · `gf` · `waybackurls` · `amass` · `Subfinder`
+`Mitmproxy` · `Frida` · `objection` · `jadx` · `apktool` · `radare2`
+`BloodHound` · `SharpHound` · `CrackMapExec` · `Rubeus`
+Cloud: `prowler` · `ScoutSuite` · `CloudFox` · IaC checks (`tfsec`, `checkov`)
 Scripting: `Python`/`Go` + custom one-offs in `Tools/`
 
 ---
@@ -112,23 +112,23 @@ I follow **coordinated disclosure**. For vendors/programs:
 ---
 
 ## Contact
-- **Email:** security@freespirits.io  
-- **Signal:** +44 7123 456789 (on request)  
-- **PGP:** see “Responsible Disclosure”  
-- **Booking:** [https://calendly.com/freespirits/consult](https://calendly.com/freespirits/consult)  
+- **Email:** security@freespirits.io
+- **Signal:** +44 7123 456789 (on request)
+- **PGP:** see “Responsible Disclosure”
+- **Booking:** [https://calendly.com/freespirits/consult](https://calendly.com/freespirits/consult)
 
 ---
 
 ### Quick Facts
-- Based in: London, UK · Timezone: Europe/London (UTC+1)  
-- Languages: Python, Go, JavaScript, Bash, English, French  
-- Insurance: Professional liability insured  
+- Based in: London, UK · Timezone: Europe/London (UTC+1)
+- Languages: Python, Go, JavaScript, Bash, English, French
+- Insurance: Professional liability insured
 - Availability: 2 weeks lead time, 2 projects/month capacity
 
 ---
 
 ## Support / Hire
-If you need a **web/API, mobile, cloud, or red-team** assessment with **tight SLAs and crisp deliverables**, reach out.  
+If you need a **web/API, mobile, cloud, or red-team** assessment with **tight SLAs and crisp deliverables**, reach out.
 I also advise engineering teams on **secure design reviews** and **SDLC hardening**.
 
 ---
@@ -136,7 +136,85 @@ I also advise engineering teams on **secure design reviews** and **SDLC hardenin
 <!-- Optional GitHub flair below -->
 <details>
   <summary>📊 GitHub Stats</summary>
-  
-  ![GitHub Streak](https://streak-stats.demolab.com?user=Freespirits&theme=default)  
+
+  ![GitHub Streak](https://streak-stats.demolab.com?user=Freespirits&theme=default)
   ![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=Freespirits&layout=compact)
 </details>
+
+---
+
+## HackTech Project Overview
+
+This repository also contains a static, multi-page rebuild of the original HackTech experience so it can be deployed directly to [Cloudflare Pages](https://developers.cloudflare.com/pages/) or any static host. The new structure mirrors all of the existing content—Daily Briefing, Breach Archives, Arsenal, and Contact—while separating reusable assets so they can be cached efficiently by Cloudflare's CDN.
+
+### Project structure
+
+```
+  public/
+    index.html                # Landing page
+    daily-briefing.html       # AI briefing page powered by Cloudflare Workers AI
+    chat-console.html         # Dedicated analyst console backed by Workers AI chat
+    ethical-hacking-tutorials.html # Curated training tracks and resources
+    breach-archives.html      # Historical case studies
+    arsenal.html              # Curated tooling collection
+    contact.html              # Secure contact form instructions
+  assets/
+    css/styles.css            # Shared visual design
+    js/matrix.js              # Matrix rain background effect
+    js/site.js                # Navigation + lucide bootstrap
+    js/briefing.js            # Front-end fetcher for the Cloudflare AI briefing
+functions/
+  api/briefing.js             # Cloudflare Pages Function proxying Workers AI
+```
+
+### Local development
+
+1. Install [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/) if you have not already.
+2. Create a `.dev.vars` file in the project root so the local dev server can reach Cloudflare AI:
+   ```bash
+   cat <<'EOF' > .dev.vars
+   CLOUDFLARE_ACCOUNT_ID=e8823131dce5e3dcaedec59bb4f7c093
+   CLOUDFLARE_AI_TOKEN=YOUR_TEMP_DEVELOPMENT_TOKEN
+   # Optional overrides if you are using a custom AI Gateway or a different model
+   # CLOUDFLARE_AI_GATEWAY_ID=my-gateway
+   # CLOUDFLARE_AI_BASE_URL=https://gateway.ai.cloudflare.com/v1/ACCOUNT/GATEWAY/workers-ai
+   # CLOUDFLARE_AI_MODEL=@cf/meta/llama-3.1-8b-instruct
+   MIDJOURNEY_PROXY_URL=https://your-midjourney-proxy.example.com
+   EOF
+   ```
+   Replace `YOUR_TEMP_DEVELOPMENT_TOKEN` with a valid API token. The token is read only by Wrangler during local development and should **not** be committed to git.
+3. Run the Pages preview with Functions support:
+   ```bash
+   npx wrangler pages dev public
+   ```
+4. Open the printed URL in your browser to view the site. The `/api/briefing` route proxies the Cloudflare AI request so your token stays server-side.
+
+### Deploying to Cloudflare Pages
+
+1. Create (or select) a Cloudflare Pages project from the dashboard.
+2. Connect the repository, set the **Framework preset** to **None**, and the **Build output directory** to `public`.
+3. In the Pages project settings, add the following environment variables under **Functions → Environment variables**:
+   - `CLOUDFLARE_ACCOUNT_ID` → `e8823131dce5e3dcaedec59bb4f7c093`
+   - `CLOUDFLARE_AI_TOKEN` → (create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the **AI** scope and paste it here)
+   - `CLOUDFLARE_AI_GATEWAY_ID` (optional) → Override the default AI Gateway identifier (`my-gateway`).
+   - `CLOUDFLARE_AI_BASE_URL` (optional) → Base URL for a [Cloudflare AI Gateway](https://developers.cloudflare.com/workers-ai/ai-gateway/) or alternate endpoint. Leave unset to use the default gateway associated with this project.
+   - `CLOUDFLARE_AI_MODEL` (optional) → Workers AI model slug (defaults to `@cf/meta/llama-3.1-8b-instruct`).
+   - `MIDJOURNEY_PROXY_URL` → URL of your deployed [midjourney-proxy](https://github.com/novicezk/midjourney-proxy) instance (for example, `https://your-midjourney-proxy.example.com`)
+4. Trigger a deploy. Cloudflare will publish every file inside `public` and execute `functions/api/briefing.js` for `/api/briefing` requests.
+5. If you prefer deploying from the CLI, run:
+   ```bash
+   npx wrangler pages deploy public
+   ```
+   When prompted, select the Pages project you configured above. Wrangler will reuse the environment variables defined in the dashboard.
+
+### Updating integrations
+
+- **Daily Briefing**: The front end calls `/api/briefing`, which in turn invokes Cloudflare's `@cf/meta/llama-3.1-8b-instruct` model via the configured AI Gateway. Adjust the prompt in `functions/api/briefing.js` or point it at a different [Cloudflare AI model](https://developers.cloudflare.com/workers-ai/models/) by changing the endpoint path or gateway configuration.
+- **Midjourney deck**: Configure `MIDJOURNEY_PROXY_URL` to point at your Midjourney proxy. Pages Functions expose `/api/midjourney/*` as a CORS-enabled pass-through so the embedded Lobe Midjourney UI can route imagine/upscale calls securely. Hit `/api/midjourney/status` to confirm the proxy is reachable—responses include a summarized payload from `/mj`.
+- **Contact form**: Replace `YOUR_UNIQUE_FORMSPREE_ENDPOINT` in `public/contact.html` with the endpoint provided by Formspree (or swap in your preferred provider).
+
+### Notes
+
+- Navigation highlighting is driven by the `data-page` attribute on `<body>`—set this value on any new page for consistent behaviour.
+- Lucide icons load from the official CDN; replace with a pinned version if you prefer long-term stability.
+- All styling uses the handcrafted CSS in `assets/css/styles.css` so you can tune the cyber aesthetic without editing each page.

--- a/functions/api/briefing.js
+++ b/functions/api/briefing.js
@@ -1,3 +1,5 @@
+import { resolveAiEndpoint } from '../../lib/cloudflare-ai.js';
+
 // Placeholders ensure deployments provide explicit credentials via environment variables.
 const DEFAULT_ACCOUNT_ID = 'demo-account-id';
 const DEFAULT_API_TOKEN = 'demo-api-token';
@@ -31,22 +33,32 @@ export async function onRequestGet(context) {
     const userPrompt = `Summarize today\'s most significant cybersecurity developments. Include:\n\n1. One major, publicly disclosed data breach.\n2. One new or updated tool relevant to ethical hacking or defense.\n3. One significant update to a major security operating system like Kali Linux or Parrot OS.\n\nFormat the response with headings for "Recent Data Breaches", "New Tools & Exploits", and "Platform Updates".`;
 
     try {
-        const aiResponse = await fetch(
-            `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/@cf/meta/llama-3-8b-instruct`,
-            {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${apiToken}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    messages: [
-                        { role: 'system', content: systemPrompt },
-                        { role: 'user', content: userPrompt },
-                    ],
-                }),
-            }
-        );
+        let endpoint;
+        try {
+            endpoint = resolveAiEndpoint(env, accountId);
+        } catch (error) {
+            return new Response(
+                JSON.stringify({ error: error.message }),
+                {
+                    status: 500,
+                    headers: { 'content-type': 'application/json' },
+                }
+            );
+        }
+
+        const aiResponse = await fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                messages: [
+                    { role: 'system', content: systemPrompt },
+                    { role: 'user', content: userPrompt },
+                ],
+            }),
+        });
 
         if (!aiResponse.ok) {
             const errorText = await aiResponse.text();

--- a/lib/cloudflare-ai.js
+++ b/lib/cloudflare-ai.js
@@ -1,0 +1,50 @@
+export const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct';
+export const DEFAULT_GATEWAY_ID = 'my-gateway';
+const GATEWAY_BASE_URL = 'https://gateway.ai.cloudflare.com/v1';
+const GATEWAY_SERVICE_SEGMENT = 'workers-ai';
+
+function normalizeModelSlug(model) {
+    return model.replace(/^\/+/, '');
+}
+
+export function resolveAiEndpoint(env, accountId) {
+    const model = normalizeModelSlug(((env?.CLOUDFLARE_AI_MODEL ?? '').trim()) || DEFAULT_MODEL);
+    const baseUrl = (env?.CLOUDFLARE_AI_BASE_URL ?? '').trim();
+
+    if (!baseUrl) {
+        const gatewayId = ((env?.CLOUDFLARE_AI_GATEWAY_ID ?? '').trim()) || DEFAULT_GATEWAY_ID;
+        return `${GATEWAY_BASE_URL}/${accountId}/${gatewayId}/${GATEWAY_SERVICE_SEGMENT}/${model}`;
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(baseUrl);
+    } catch (error) {
+        throw new Error('CLOUDFLARE_AI_BASE_URL must be a valid absolute URL.');
+    }
+
+    const trimmedPath = parsed.pathname.replace(/\/+$/, '');
+    const segments = trimmedPath
+        .split('/')
+        .map((segment) => segment.trim())
+        .filter(Boolean);
+    const endsWithService = segments[segments.length - 1] === GATEWAY_SERVICE_SEGMENT;
+    const isGatewayHost = parsed.hostname === 'gateway.ai.cloudflare.com';
+
+    let normalizedPath;
+    if (isGatewayHost) {
+        normalizedPath = endsWithService ? `${trimmedPath}/` : `${trimmedPath}/${GATEWAY_SERVICE_SEGMENT}/`;
+    } else {
+        normalizedPath = `${trimmedPath}/`;
+    }
+
+    if (!normalizedPath.startsWith('/')) {
+        normalizedPath = `/${normalizedPath}`;
+    }
+
+    normalizedPath = normalizedPath.replace(/\/{2,}/g, '/');
+
+    parsed.pathname = normalizedPath;
+
+    return `${parsed.toString()}${model}`;
+}

--- a/tests/briefing.test.js
+++ b/tests/briefing.test.js
@@ -2,6 +2,7 @@ import { test, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { onRequestGet } from '../functions/api/briefing.js';
+import { DEFAULT_GATEWAY_ID, DEFAULT_MODEL } from '../lib/cloudflare-ai.js';
 
 const originalFetch = globalThis.fetch;
 const originalCaches = globalThis.caches;
@@ -110,9 +111,10 @@ test('onRequestGet uses default credentials when missing', async () => {
     assert.equal(response.status, 200);
     const payload = await response.clone().json();
     assert.equal(payload.markdown, '### Recent Data Breaches\n* fallback detail');
+    const normalizedModel = DEFAULT_MODEL.replace(/^\/+/, '');
     assert.equal(
         calls[0][0],
-        'https://api.cloudflare.com/client/v4/accounts/demo-account-id/ai/run/@cf/meta/llama-3-8b-instruct'
+        `https://gateway.ai.cloudflare.com/v1/demo-account-id/${DEFAULT_GATEWAY_ID}/workers-ai/${normalizedModel}`
     );
     assert.equal(calls[0][1].headers.Authorization, 'Bearer demo-api-token');
 });


### PR DESCRIPTION
## Summary
- update the Cloudflare AI helper to target the workers-ai segment and new default model/gateway id
- refresh README guidance to highlight the my-gateway default and llama-3.1-8b model
- adjust the briefing and chat tests to assert the updated gateway URL pattern

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b8d2dd6c83278446749e8cead899