### PR TITLE
Remove Cloudflare Workers AI functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ I break things (legally) so you don’t get broken into. I deliver **clear, repr
 ---
 
 ## Methodology (Standards-Aligned)
-- **Scoping & Threat Modeling:** assets, data flows, abuse cases, impact map  
-- **Recon & Mapping:** OSINT, content discovery, API enumerations, attack surface diff  
+- **Scoping & Threat Modeling:** assets, data flows, abuse cases, impact map
+- **Recon & Mapping:** OSINT, content discovery, API enumerations, attack surface diff
 - **Exploitation:** safe PoCs, **no destructive payloads**; chain to business impact  
 - **Post-Exploitation:** data access proof, least-privilege escalation checks  
-- **Reporting:** CVSS/CWEs, reproducible steps, screenshots, **fix-first guidance**  
+- **Reporting:** CVSS/CWEs, reproducible steps, screenshots, **fix-first guidance**
 - **Validation:** retest window + remediation verification
 
 > References: PTES · OWASP WSTG/MASVS/MSTG · NIST 800-115 · OSSTMM
@@ -43,10 +43,10 @@ I break things (legally) so you don’t get broken into. I deliver **clear, repr
 ---
 
 ## Tooling (Representative)
-`Burp Suite Pro` · `ffuf` · `httpx` · `nuclei` · `kxss` · `gf` · `waybackurls` · `amass` · `Subfinder`  
-`Mitmproxy` · `Frida` · `objection` · `jadx` · `apktool` · `radare2`  
-`BloodHound` · `SharpHound` · `CrackMapExec` · `Rubeus`  
-Cloud: `prowler` · `ScoutSuite` · `CloudFox` · IaC checks (`tfsec`, `checkov`)  
+`Burp Suite Pro` · `ffuf` · `httpx` · `nuclei` · `kxss` · `gf` · `waybackurls` · `amass` · `Subfinder`
+`Mitmproxy` · `Frida` · `objection` · `jadx` · `apktool` · `radare2`
+`BloodHound` · `SharpHound` · `CrackMapExec` · `Rubeus`
+Cloud: `prowler` · `ScoutSuite` · `CloudFox` · IaC checks (`tfsec`, `checkov`)
 Scripting: `Python`/`Go` + custom one-offs in `Tools/`
 
 ---
@@ -112,23 +112,23 @@ I follow **coordinated disclosure**. For vendors/programs:
 ---
 
 ## Contact
-- **Email:** security@freespirits.io  
-- **Signal:** +44 7123 456789 (on request)  
-- **PGP:** see “Responsible Disclosure”  
-- **Booking:** [https://calendly.com/freespirits/consult](https://calendly.com/freespirits/consult)  
+- **Email:** security@freespirits.io
+- **Signal:** +44 7123 456789 (on request)
+- **PGP:** see “Responsible Disclosure”
+- **Booking:** [https://calendly.com/freespirits/consult](https://calendly.com/freespirits/consult)
 
 ---
 
 ### Quick Facts
-- Based in: London, UK · Timezone: Europe/London (UTC+1)  
-- Languages: Python, Go, JavaScript, Bash, English, French  
-- Insurance: Professional liability insured  
+- Based in: London, UK · Timezone: Europe/London (UTC+1)
+- Languages: Python, Go, JavaScript, Bash, English, French
+- Insurance: Professional liability insured
 - Availability: 2 weeks lead time, 2 projects/month capacity
 
 ---
 
 ## Support / Hire
-If you need a **web/API, mobile, cloud, or red-team** assessment with **tight SLAs and crisp deliverables**, reach out.  
+If you need a **web/API, mobile, cloud, or red-team** assessment with **tight SLAs and crisp deliverables**, reach out.
 I also advise engineering teams on **secure design reviews** and **SDLC hardening**.
 
 ---
@@ -136,7 +136,74 @@ I also advise engineering teams on **secure design reviews** and **SDLC hardenin
 <!-- Optional GitHub flair below -->
 <details>
   <summary>📊 GitHub Stats</summary>
-  
-  ![GitHub Streak](https://streak-stats.demolab.com?user=Freespirits&theme=default)  
+
+  ![GitHub Streak](https://streak-stats.demolab.com?user=Freespirits&theme=default)
   ![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=Freespirits&layout=compact)
 </details>
+
+---
+
+## HackTech Project Overview
+
+This repository also contains a static, multi-page rebuild of the original HackTech experience so it can be deployed directly to [Cloudflare Pages](https://developers.cloudflare.com/pages/) or any static host. The new structure mirrors all of the existing content—Daily Briefing, Breach Archives, Arsenal, and Contact—while separating reusable assets so they can be cached efficiently by Cloudflare's CDN.
+
+### Project structure
+
+```
+  public/
+    index.html                # Landing page
+    daily-briefing.html       # Static notice about the retired daily briefing feed
+    chat-console.html         # Analyst console replaced with a retirement notice
+    ethical-hacking-tutorials.html # Curated training tracks and resources
+    breach-archives.html      # Historical case studies
+    arsenal.html              # Curated tooling collection
+    contact.html              # Secure contact form instructions
+  assets/
+    css/styles.css            # Shared visual design
+    js/matrix.js              # Matrix rain background effect
+    js/site.js                # Navigation + lucide bootstrap
+    js/briefing.js            # Front-end script that renders the retirement notice
+functions/
+  api/briefing.js             # Pages Function returning a 410 Gone retirement response
+```
+
+### Local development
+
+1. Install [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/) if you have not already.
+2. Create a `.dev.vars` file in the project root with any secrets required for optional integrations:
+   ```bash
+   cat <<'EOF' > .dev.vars
+   MIDJOURNEY_PROXY_URL=https://your-midjourney-proxy.example.com
+   EOF
+   ```
+   The daily briefing and chat console are now static retirement notices and no longer require Cloudflare Workers AI credentials.
+3. Run the Pages preview with Functions support:
+   ```bash
+   npx wrangler pages dev public
+   ```
+4. Open the printed URL in your browser to view the site. The `/api/briefing` route now returns a 410 Gone response signalling that the feed has been retired.
+
+### Deploying to Cloudflare Pages
+
+1. Create (or select) a Cloudflare Pages project from the dashboard.
+2. Connect the repository, set the **Framework preset** to **None**, and the **Build output directory** to `public`.
+3. In the Pages project settings, add any optional environment variables under **Functions → Environment variables**:
+   - `MIDJOURNEY_PROXY_URL` → URL of your deployed [midjourney-proxy](https://github.com/novicezk/midjourney-proxy) instance (for example, `https://your-midjourney-proxy.example.com`)
+4. Trigger a deploy. Cloudflare will publish every file inside `public` and execute `functions/api/briefing.js` for `/api/briefing` requests, which now return the 410 Gone retirement notice.
+5. If you prefer deploying from the CLI, run:
+   ```bash
+   npx wrangler pages deploy public
+   ```
+   When prompted, select the Pages project you configured above. Wrangler will reuse the environment variables defined in the dashboard.
+
+### Updating integrations
+
+- **Daily Briefing**: The front end now renders a static retirement notice. `/api/briefing` returns a 410 Gone response so any legacy clients know the feed is offline.
+- **Midjourney deck**: Configure `MIDJOURNEY_PROXY_URL` to point at your Midjourney proxy. Pages Functions expose `/api/midjourney/*` as a CORS-enabled pass-through so the embedded Lobe Midjourney UI can route imagine/upscale calls securely. Hit `/api/midjourney/status` to confirm the proxy is reachable—responses include a summarized payload from `/mj`.
+- **Contact form**: Replace `YOUR_UNIQUE_FORMSPREE_ENDPOINT` in `public/contact.html` with the endpoint provided by Formspree (or swap in your preferred provider).
+
+### Notes
+
+- Navigation highlighting is driven by the `data-page` attribute on `<body>`—set this value on any new page for consistent behaviour.
+- Lucide icons load from the official CDN; replace with a pinned version if you prefer long-term stability.
+- All styling uses the handcrafted CSS in `assets/css/styles.css` so you can tune the cyber aesthetic without editing each page.

--- a/functions/api/briefing.js
+++ b/functions/api/briefing.js
@@ -1,97 +1,19 @@
-// Placeholders ensure deployments provide explicit credentials via environment variables.
-const DEFAULT_ACCOUNT_ID = 'demo-account-id';
-const DEFAULT_API_TOKEN = 'demo-api-token';
+const JSON_HEADERS = Object.freeze({ 'content-type': 'application/json' });
 
-export async function onRequestGet(context) {
-    const { env, request, waitUntil } = context;
-    const cache = caches.default;
-    const cacheKey = new Request(request);
+const RETIRED_PAYLOAD = Object.freeze({
+    error: 'The daily briefing feed has been retired.',
+    notice: 'Cloudflare Workers AI integrations have been removed from this project.',
+});
 
-    const cachedResponse = await cache.match(cacheKey);
-    if (cachedResponse) {
-        return cachedResponse;
-    }
-
-    const normalize = (value) => (typeof value === 'string' ? value.trim() : '');
-
-    const accountId = normalize(env.CLOUDFLARE_ACCOUNT_ID) || DEFAULT_ACCOUNT_ID;
-    const apiToken = normalize(env.CLOUDFLARE_AI_TOKEN) || DEFAULT_API_TOKEN;
-
-    if (!accountId || !apiToken) {
-        return new Response(
-            JSON.stringify({ error: 'Cloudflare AI environment variables are not configured.' }),
-            {
-                status: 500,
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    }
-
-    const systemPrompt = 'You are a world-class cybersecurity intelligence analyst. Provide concise daily threat intel.';
-    const userPrompt = `Summarize today\'s most significant cybersecurity developments. Include:\n\n1. One major, publicly disclosed data breach.\n2. One new or updated tool relevant to ethical hacking or defense.\n3. One significant update to a major security operating system like Kali Linux or Parrot OS.\n\nFormat the response with headings for "Recent Data Breaches", "New Tools & Exploits", and "Platform Updates".`;
-
-    try {
-        const aiResponse = await fetch(
-            `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/@cf/meta/llama-3-8b-instruct`,
-            {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${apiToken}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    messages: [
-                        { role: 'system', content: systemPrompt },
-                        { role: 'user', content: userPrompt },
-                    ],
-                }),
-            }
-        );
-
-        if (!aiResponse.ok) {
-            const errorText = await aiResponse.text();
-            throw new Error(`Cloudflare AI error: ${aiResponse.status} ${aiResponse.statusText} - ${errorText}`);
-        }
-
-        const result = await aiResponse.json();
-        const aiText =
-            result?.result?.response ??
-            result?.result?.output_text ??
-            result?.result?.text ??
-            result?.result ??
-            null;
-
-        if (!aiText || typeof aiText !== 'string') {
-            throw new Error('Unexpected response from Cloudflare AI');
-        }
-
-        const responseBody = JSON.stringify({
-            markdown: aiText,
-            generatedAt: new Date().toISOString(),
-        });
-
-        const response = new Response(responseBody, {
-            headers: {
-                'content-type': 'application/json',
-                'cache-control': 'public, max-age=0, s-maxage=7200',
-            },
-        });
-
-        if (typeof waitUntil === 'function') {
-            waitUntil(cache.put(cacheKey, response.clone()));
-        } else {
-            await cache.put(cacheKey, response.clone());
-        }
-
-        return response;
-    } catch (error) {
-        console.error('Daily briefing function error:', error);
-        return new Response(
-            JSON.stringify({ error: 'Failed to retrieve intelligence briefing. Check server logs for details.' }),
-            {
-                status: 500,
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    }
+function buildGoneResponse() {
+    return new Response(JSON.stringify(RETIRED_PAYLOAD), {
+        status: 410,
+        headers: JSON_HEADERS,
+    });
 }
+
+export async function onRequestGet() {
+    return buildGoneResponse();
+}
+
+export const onRequest = onRequestGet;

--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -1,14 +1,3 @@
-const DEFAULT_SYSTEM_PROMPT = [
-    'You are the on-call HackTech cyber intelligence analyst embedded in a defensive operations team.',
-    'Respond with precise, actionable insight rooted in cybersecurity best practices.',
-    'Reference known frameworks (MITRE ATT&CK, NIST, CIS) when useful and keep answers under 220 words unless additional detail is requested.',
-    'Use paragraphs or concise lists rather than markdown headings.',
-].join(' ');
-
-const DEFAULT_MODEL = '@cf/meta/llama-3-8b-instruct';
-// Intentionally non-functional placeholders so real credentials must be supplied via env vars.
-const DEFAULT_ACCOUNT_ID = 'demo-account-id';
-const DEFAULT_API_TOKEN = 'demo-api-token';
 const CORS_HEADERS = Object.freeze({
     'content-type': 'application/json',
     'access-control-allow-origin': '*',
@@ -16,68 +5,20 @@ const CORS_HEADERS = Object.freeze({
     'access-control-allow-headers': 'content-type',
 });
 
-function sanitizeMessages(rawMessages) {
-    const allowedRoles = new Set(['system', 'user', 'assistant']);
-    const conversation = [];
-    let systemPrompt = null;
+const RETIRED_PAYLOAD = Object.freeze({
+    error: 'The live analyst chat has been retired.',
+    notice: 'Cloudflare Workers AI integrations have been removed from this project.',
+});
 
-    for (const message of rawMessages) {
-        if (!message || typeof message !== 'object') {
-            continue;
-        }
-
-        const role = typeof message.role === 'string' ? message.role.toLowerCase() : 'user';
-        const content = typeof message.content === 'string' ? message.content.trim() : '';
-
-        if (!content || !allowedRoles.has(role)) {
-            continue;
-        }
-
-        if (role === 'system') {
-            if (!systemPrompt) {
-                systemPrompt = content;
-            }
-            continue;
-        }
-
-        conversation.push({ role, content });
-    }
-
-    while (conversation.length > 0 && conversation[0].role === 'assistant') {
-        conversation.shift();
-    }
-
-    if (!conversation.some((entry) => entry.role === 'user')) {
-        return { error: 'At least one user message is required.' };
-    }
-
-    return {
-        systemPrompt: systemPrompt || DEFAULT_SYSTEM_PROMPT,
-        conversation: conversation.slice(-12),
-    };
-}
-
-function resolveModelEndpoint(env, accountId) {
-    const model = (env.CLOUDFLARE_AI_MODEL || '').trim() || DEFAULT_MODEL;
-    const baseUrl = (env.CLOUDFLARE_AI_BASE_URL || '').trim();
-
-    if (!baseUrl) {
-        return `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model.replace(/^\//, '')}`;
-    }
-
-    try {
-        const parsed = new URL(baseUrl);
-        if (!parsed.pathname.endsWith('/')) {
-            parsed.pathname = `${parsed.pathname}/`;
-        }
-        return `${parsed.toString()}${model.replace(/^\//, '')}`;
-    } catch (error) {
-        throw new Error('CLOUDFLARE_AI_BASE_URL must be a valid absolute URL.');
-    }
+function buildGoneResponse() {
+    return new Response(JSON.stringify(RETIRED_PAYLOAD), {
+        status: 410,
+        headers: CORS_HEADERS,
+    });
 }
 
 export async function onRequestPost(context) {
-    const { env, request } = context;
+    const { request } = context;
 
     if (request.method !== 'POST') {
         return new Response('Method Not Allowed', {
@@ -86,115 +27,8 @@ export async function onRequestPost(context) {
         });
     }
 
-    const normalize = (value) => (typeof value === 'string' ? value.trim() : '');
-
-    const accountId = normalize(env.CLOUDFLARE_ACCOUNT_ID) || DEFAULT_ACCOUNT_ID;
-    const apiToken = normalize(env.CLOUDFLARE_AI_TOKEN) || DEFAULT_API_TOKEN;
-
-    if (!accountId || !apiToken) {
-        return new Response(JSON.stringify({ error: 'Cloudflare AI environment variables are not configured.' }), {
-            status: 500,
-            headers: CORS_HEADERS,
-        });
-    }
-
-    let body;
-    try {
-        body = await request.json();
-    } catch (error) {
-        return new Response(JSON.stringify({ error: 'Invalid JSON payload.' }), {
-            status: 400,
-            headers: CORS_HEADERS,
-        });
-    }
-
-    const rawMessages = Array.isArray(body?.messages) ? body.messages : [];
-    if (rawMessages.length === 0) {
-        return new Response(JSON.stringify({ error: 'At least one message is required.' }), {
-            status: 400,
-            headers: CORS_HEADERS,
-        });
-    }
-
-    const { systemPrompt, conversation, error: validationError } = sanitizeMessages(rawMessages);
-    if (validationError) {
-        return new Response(JSON.stringify({ error: validationError }), {
-            status: 400,
-            headers: CORS_HEADERS,
-        });
-    }
-
-    let endpoint;
-    try {
-        endpoint = resolveModelEndpoint(env, accountId);
-    } catch (error) {
-        return new Response(JSON.stringify({ error: error.message }), {
-            status: 500,
-            headers: CORS_HEADERS,
-        });
-    }
-
-    const messages = [{ role: 'system', content: systemPrompt }, ...conversation];
-
-    try {
-        const aiResponse = await fetch(endpoint, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${apiToken}`,
-                'Content-Type': 'application/json',
-                Accept: 'application/json',
-            },
-            body: JSON.stringify({ messages }),
-        });
-
-        if (!aiResponse.ok) {
-            const errorText = await aiResponse.text();
-            throw new Error(`Cloudflare AI error: ${aiResponse.status} ${aiResponse.statusText} - ${errorText}`);
-        }
-
-        const result = await aiResponse.json();
-        const candidates = [
-            result?.result?.response,
-            result?.result?.output_text,
-            result?.result?.text,
-            result?.result?.choices?.[0]?.message?.content,
-            result?.result?.choices?.[0]?.text,
-            result?.result?.data?.[0]?.text,
-            result?.choices?.[0]?.message?.content,
-            result?.choices?.[0]?.text,
-            result?.data?.[0]?.text,
-            result?.response,
-            result?.output_text,
-            result?.text,
-            typeof result?.result === 'string' ? result.result : null,
-            typeof result === 'string' ? result : null,
-        ];
-
-        const aiText = candidates.find((entry) => typeof entry === 'string' && entry.trim());
-
-        if (!aiText) {
-            throw new Error('Unexpected response from Cloudflare AI');
-        }
-
-        return new Response(JSON.stringify({ reply: aiText.trim(), createdAt: new Date().toISOString() }), {
-            headers: CORS_HEADERS,
-        });
-    } catch (error) {
-        console.error('Analyst chat function error:', error);
-
-        const payload = {
-            error: 'Unable to retrieve analyst response. Check Cloudflare logs for details.',
-        };
-
-        if (error instanceof Error && error.message) {
-            payload.details = error.message;
-        }
-
-        return new Response(JSON.stringify(payload), {
-            status: 500,
-            headers: CORS_HEADERS,
-        });
-    }
+    // Always respond with a gone notice so clients know the integration has been removed.
+    return buildGoneResponse();
 }
 
 export function onRequestOptions() {

--- a/public/assets/js/briefing.js
+++ b/public/assets/js/briefing.js
@@ -1,134 +1,20 @@
-const fallbackBriefings = [
-    {
-        generatedAt: '2024-03-18T08:00:00Z',
-        markdown: `### Recent Data Breaches\n* **Change Healthcare** disclosed that ransomware actors used a stolen Citrix account to drop "Hello Kitty" (FiveHands) payloads, disrupting pharmacy services across the United States. The company is rotating credentials, hardening remote access, and coordinating with CISA on shared indicators.\n### New Tools & Exploits\n* **Burp Suite 2024.1** introduced a passive API discovery add-on that maps undocumented endpoints and flags unsafe CORS rules—ideal for purple-team reviews.\n### Platform Updates\n* **Kali Linux 2024.1** refreshed its Kernel to 6.6 and added the open-source AutoRecon 2 framework to the default repositories, accelerating service enumeration workflows.`,
-    },
-    {
-        generatedAt: '2024-03-26T08:00:00Z',
-        markdown: `### Recent Data Breaches\n* **UnitedHealth Group** confirmed follow-on data theft from the same ALPHV affiliate that hit Change Healthcare. Investigators report exfiltration of claims data; credential resets and segmented network monitoring are underway.\n### New Tools & Exploits\n* **ProjectDiscovery released nuclei-templates v9.8.0**, bundling checks for Ivanti Connect Secure command-injection CVEs (2024-21887/21893) and Atlassian Confluence auth bypasses—deployable in defensive watchlists.\n### Platform Updates\n* **Parrot OS 6.1** shipped a hardened Firefox ESR build and refreshed AppArmor profiles, reducing noise when running blue-team forensic utilities.`,
-    },
-    {
-        generatedAt: '2024-04-02T08:00:00Z',
-        markdown: `### Recent Data Breaches\n* **Fujitsu** reported a corporate network intrusion attributed to a credential-stuffing campaign abusing recycled VPN passwords. Impacted employees underwent forced resets and FIDO2 rollouts.\n### New Tools & Exploits\n* **CISA's RedEye 3.0** now parses Cobalt Strike beacon logs and can auto-generate containment runbooks—perfect for blue-team rehearsals.\n### Platform Updates\n* **BlackArch 2024.03.01** added 150+ new packages, including Kerbrute 2.0 and updated bloodhound.py, tightening support for Active Directory attack emulation.`,
-    },
-    {
-        generatedAt: '2024-04-18T08:00:00Z',
-        markdown: `### Recent Data Breaches\n* **London Clinic Pegasus inquiry**: UK regulators disclosed that infrastructure tied to NSO Group's Pegasus spyware was used to surveil lawyers working the Post Office Horizon case. Mobile carriers rotated IMSI catchers, while the victims replaced handsets and deployed mobile EDR.\n### New Tools & Exploits\n* **Velociraptor 0.7.1** shipped enterprise-ready remote collection with granular RBAC, giving responders a sanctioned alternative to commodity RAT tooling when investigating lateral movement.\n### Platform Updates\n* **Microsoft Entra ID** added granular continuous access evaluation logs for Remote Desktop Protocol (RDP) sign-ins, closing blind spots defenders saw during the Storm-1811 social-engineering spree.`,
-    },
-];
-
-function selectFallbackBriefing() {
-    if (!Array.isArray(fallbackBriefings) || fallbackBriefings.length === 0) {
-        return null;
-    }
-
-    const today = new Date();
-    const index = Math.abs(today.getUTCDate() + today.getUTCMonth()) % fallbackBriefings.length;
-    return fallbackBriefings[index];
-}
-
-function renderFallbackBriefing(error) {
-    console.warn('Using fallback briefing due to live feed error:', error);
-    const fallback = selectFallbackBriefing();
-
-    if (!fallback) {
-        renderError('Could not connect to the intelligence grid. Check the console for details.');
+function renderRetiredBriefing() {
+    const container = document.getElementById('briefing-content');
+    if (!container) {
         return;
     }
 
-    renderBriefing(fallback.markdown, fallback.generatedAt, { isFallback: true });
+    container.innerHTML = `
+        <div class="data-card">
+            <div class="briefing-meta font-mono">
+                <span class="meta-pill">Feed retired</span>
+            </div>
+            <p class="briefing-paragraph">
+                The automated daily briefing is offline and no longer pulls from Cloudflare Workers AI. Explore the tutorials,
+                breach archives, and knowledge hub pages for training material instead.
+            </p>
+        </div>
+    `;
 }
 
-async function fetchDailyBriefing() {
-    try {
-        const response = await fetch('/api/briefing');
-
-        if (!response.ok) {
-            throw new Error(`API Error: ${response.status} ${response.statusText}`);
-        }
-
-        const payload = await response.json();
-
-        if (payload?.error) {
-            throw new Error(payload.error);
-        }
-
-        if (typeof payload?.markdown === 'string') {
-            renderBriefing(payload.markdown, payload.generatedAt);
-        } else {
-            throw new Error('Malformed response payload');
-        }
-    } catch (error) {
-        console.error('Error fetching daily briefing:', error);
-        renderFallbackBriefing(error);
-    }
-}
-
-function escapeHtml(value) {
-    if (value == null) {
-        return '';
-    }
-
-    const escapeMap = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;',
-    };
-
-    return String(value).replace(/[&<>"']/g, (char) => escapeMap[char]);
-}
-
-function renderBriefing(rawText, generatedAt, options = {}) {
-    const { isFallback = false } = options;
-    const container = document.getElementById('briefing-content');
-    if (!container) return;
-
-    const escapedText = escapeHtml(rawText);
-
-    const htmlContent = escapedText
-        .replace(/### (.*)/g, '<span class="highlight-heading font-mono">&gt;&gt; $1</span>')
-        .replace(/\*\*([^*]+)\*\*/g, '<strong class="text-strong">$1</strong>')
-        .replace(/\* ([^*]+)/g, '<p class="briefing-paragraph">$1</p>')
-        .replace(/\n/g, '<br>');
-
-    const metaBlock = [
-        '<div class="briefing-meta font-mono">',
-        '<span class="meta-pill">Automated refresh every 2 hours</span>',
-        generatedAt ? `<span class="meta-timestamp">Last updated: ${formatTimestamp(generatedAt)}</span>` : '',
-        '</div>',
-    ].join('');
-
-    const fallbackNotice = isFallback
-        ? '<p class="fallback-notice">Live feed temporarily offline — displaying a curated training briefing instead.</p>'
-        : '';
-
-    container.innerHTML = `<div class="data-card">${metaBlock}${htmlContent}${fallbackNotice}</div>`;
-}
-
-function renderError(message) {
-    const container = document.getElementById('briefing-content');
-    if (container) {
-        container.innerHTML = `<p class="font-mono" style="color: #f87171; text-align: center;">${message}</p>`;
-    }
-}
-
-function formatTimestamp(isoString) {
-    try {
-        const date = new Date(isoString);
-        if (Number.isNaN(date.getTime())) {
-            return isoString;
-        }
-
-        return new Intl.DateTimeFormat(undefined, {
-            dateStyle: 'medium',
-            timeStyle: 'short',
-        }).format(date);
-    } catch (error) {
-        console.warn('Unable to format timestamp:', error);
-        return isoString;
-    }
-}
-
-document.addEventListener('DOMContentLoaded', fetchDailyBriefing);
+document.addEventListener('DOMContentLoaded', renderRetiredBriefing);

--- a/public/assets/js/chat.js
+++ b/public/assets/js/chat.js
@@ -1,266 +1,44 @@
-const systemMessage = {
-    role: 'system',
-    content:
-        'You are a world-class cybersecurity analyst supporting HackTech operators across briefings and training missions. Provide concise, technically accurate insights, emphasize lawful defensive actions, and suggest next steps when helpful.',
-};
+function disableChatConsole() {
+    const thread = document.getElementById('chat-thread');
+    const form = document.getElementById('chat-form');
+    const input = document.getElementById('chat-input');
+    const sendButton = document.querySelector('[data-chat-send]');
 
-const conversation = [systemMessage];
-const MAX_HISTORY = 14;
-
-function extractReply(payload) {
-    if (!payload) {
-        return '';
-    }
-
-    if (typeof payload === 'string') {
-        return payload.trim();
-    }
-
-    if (typeof payload !== 'object') {
-        return '';
-    }
-
-    const directReply = payload.reply;
-    if (typeof directReply === 'string' && directReply.trim()) {
-        return directReply.trim();
-    }
-
-    const containers = [payload, payload?.result];
-
-    for (const container of containers) {
-        if (!container) {
-            continue;
-        }
-
-        if (typeof container === 'string') {
-            const trimmed = container.trim();
-            if (trimmed) {
-                return trimmed;
-            }
-            continue;
-        }
-
-        if (typeof container !== 'object') {
-            continue;
-        }
-
-        const directFields = [container.reply, container.response, container.output_text, container.text];
-        for (const field of directFields) {
-            if (typeof field === 'string' && field.trim()) {
-                return field.trim();
-            }
-        }
-
-        const dataEntry = container.data?.[0];
-        if (dataEntry) {
-            const dataCandidates = [dataEntry.message?.content, dataEntry.text];
-            for (const candidate of dataCandidates) {
-                if (typeof candidate === 'string' && candidate.trim()) {
-                    return candidate.trim();
-                }
-            }
-        }
-
-        const choice = container.choices?.[0];
-        if (choice) {
-            const choiceCandidates = [choice.message?.content, choice.text];
-            for (const option of choiceCandidates) {
-                if (typeof option === 'string' && option.trim()) {
-                    return option.trim();
-                }
-            }
-        }
-    }
-
-    return '';
-}
-
-function snapshotConversation() {
-    const recent = conversation.slice(-MAX_HISTORY);
-    const hasSystem = recent.some((entry) => entry.role === 'system');
-    if (!hasSystem && conversation[0]?.role === 'system') {
-        recent.unshift(conversation[0]);
-    }
-    return recent;
-}
-
-function getElements() {
-    return {
-        thread: document.getElementById('chat-thread'),
-        form: document.getElementById('chat-form'),
-        input: document.getElementById('chat-input'),
-        sendButton: document.querySelector('[data-chat-send]'),
-        wrapper: document.querySelector('[data-chat-wrapper]'),
-    };
-}
-
-function appendMessage(role, content) {
-    const { thread } = getElements();
-    if (!thread) return null;
-
-    const message = document.createElement('div');
-    message.className = 'chat-message';
-    message.dataset.role = role;
-
-    const header = document.createElement('header');
-    header.textContent = role === 'user' ? 'Operative' : 'Analyst';
-
-    const bubble = document.createElement('div');
-    bubble.className = 'chat-bubble';
-    bubble.textContent = content;
-
-    message.appendChild(header);
-    message.appendChild(bubble);
-    thread.appendChild(message);
-    thread.scrollTop = thread.scrollHeight;
-    return message;
-}
-
-function createTypingIndicator() {
-    const indicator = document.createElement('div');
-    indicator.className = 'chat-message';
-    indicator.dataset.role = 'assistant';
-    indicator.dataset.state = 'typing';
-
-    const header = document.createElement('header');
-    header.textContent = 'Analyst';
-
-    const bubble = document.createElement('div');
-    bubble.className = 'chat-bubble';
-
-    const status = document.createElement('span');
-    status.className = 'chat-status';
-    status.textContent = 'Synthesizing intel';
-
-    const dots = document.createElement('span');
-    dots.className = 'loading-dots';
-    dots.innerHTML = '<span></span><span></span><span></span>';
-
-    status.appendChild(dots);
-    bubble.appendChild(status);
-
-    indicator.appendChild(header);
-    indicator.appendChild(bubble);
-    return indicator;
-}
-
-function setBusyState(isBusy) {
-    const { sendButton, wrapper, thread } = getElements();
-    if (sendButton) {
-        sendButton.disabled = isBusy;
-    }
-    if (wrapper) {
-        wrapper.setAttribute('aria-busy', isBusy ? 'true' : 'false');
-    }
     if (thread) {
-        thread.setAttribute('aria-busy', isBusy ? 'true' : 'false');
-    }
-}
+        const message = document.createElement('div');
+        message.className = 'chat-message';
+        message.dataset.role = 'assistant';
 
-async function transmitMessage(event) {
-    event.preventDefault();
-    const { input, thread } = getElements();
-    if (!input || !thread) {
-        return;
-    }
+        const header = document.createElement('header');
+        header.textContent = 'Analyst';
 
-    const userMessage = input.value.trim();
-    if (!userMessage) {
-        return;
-    }
+        const bubble = document.createElement('div');
+        bubble.className = 'chat-bubble';
+        bubble.textContent =
+            'The live analyst console has been retired alongside the Cloudflare Workers AI integration. Review the training materials and briefing archives for guidance.';
 
-    appendMessage('user', userMessage);
-    conversation.push({ role: 'user', content: userMessage });
-    input.value = '';
-    input.style.height = '';
-
-    const typingIndicator = createTypingIndicator();
-    thread.appendChild(typingIndicator);
-    thread.scrollTop = thread.scrollHeight;
-
-    setBusyState(true);
-
-    try {
-        const response = await fetch('/api/chat', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ messages: snapshotConversation() }),
-        });
-
-        if (!response.ok) {
-            let errorMessage = `Chat API error: ${response.status}`;
-            try {
-                const errorPayload = await response.clone().json();
-                if (typeof errorPayload?.error === 'string' && errorPayload.error.trim()) {
-                    errorMessage = errorPayload.error.trim();
-                    if (typeof errorPayload.details === 'string' && errorPayload.details.trim()) {
-                        errorMessage = `${errorMessage} (${errorPayload.details.trim()})`;
-                    }
-                }
-            } catch (parseError) {
-                console.warn('Unable to parse chat error payload:', parseError);
-            }
-
-            throw new Error(errorMessage);
-        }
-
-        const payload = await response.json();
-        const reply = extractReply(payload);
-
-        if (!reply) {
-            throw new Error('Empty response from analyst');
-        }
-
-        conversation.push({ role: 'assistant', content: reply });
-        typingIndicator.remove();
-        appendMessage('assistant', reply);
-    } catch (error) {
-        console.error('Chat console error:', error);
-        typingIndicator.remove();
-        const reason = error instanceof Error && error.message ? ` (${error.message})` : '';
-        appendMessage(
-            'assistant',
-            `Signal lost while contacting the analyst. Check your connection and try again.${reason}`.trim()
-        );
-    } finally {
-        setBusyState(false);
-    }
-}
-
-function autoResize(event) {
-    const field = event.target;
-    if (!(field instanceof HTMLTextAreaElement)) {
-        return;
-    }
-    field.style.height = 'auto';
-    field.style.height = `${Math.min(field.scrollHeight, 320)}px`;
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    const { form, input } = getElements();
-    if (!form || !input) {
-        return;
+        message.appendChild(header);
+        message.appendChild(bubble);
+        thread.appendChild(message);
     }
 
-    appendMessage(
-        'assistant',
-        'Welcome back, operative. I can expand on briefing intel, craft training plans, or outline mitigation steps. What signal should we decode first?'
-    );
-    conversation.push({
-        role: 'assistant',
-        content:
-            'Welcome back, operative. I can expand on briefing intel, craft training plans, or outline mitigation steps. What signal should we decode first?',
-    });
+    if (input) {
+        input.disabled = true;
+        input.value = '';
+        input.setAttribute('aria-disabled', 'true');
+        input.placeholder = 'Analyst console retired.';
+    }
 
-    form.addEventListener('submit', transmitMessage);
-    input.addEventListener('input', autoResize);
+    if (sendButton) {
+        sendButton.disabled = true;
+        sendButton.setAttribute('aria-disabled', 'true');
+    }
 
-    input.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' && !event.shiftKey) {
+    if (form) {
+        form.addEventListener('submit', (event) => {
             event.preventDefault();
-            form.requestSubmit();
-        }
-    });
-});
+        });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', disableChatConsole);

--- a/public/chat-console.html
+++ b/public/chat-console.html
@@ -37,7 +37,7 @@
         <section class="cyber-panel" aria-labelledby="chat-console-heading">
             <h2 id="chat-console-heading"><i data-lucide="messages-square"></i> Analyst Chat Console</h2>
             <p class="highlight">
-                The console links you directly with HackTech's embedded analyst. Ask for deeper context on a briefing item, talk through mitigation strategies, or map the next steps of an engagement. Responses are sourced from Cloudflare Workers AI and tuned for lawful, defensive operations.
+                The live analyst feed has been retired while Cloudflare Workers AI access is offline. The console now returns archived guidance so you can reference past playbooks and workflows while the real-time integration is rebuilt.
             </p>
             <div class="chat-layout">
                 <div class="chat-intel">

--- a/public/daily-briefing.html
+++ b/public/daily-briefing.html
@@ -37,9 +37,9 @@
         </nav>
         <div class="briefing-layout">
             <section class="cyber-panel" aria-labelledby="daily-briefing-heading">
-                <h2 id="daily-briefing-heading"><i data-lucide="shield-check"></i> AI-Powered Daily Briefing</h2>
+                <h2 id="daily-briefing-heading"><i data-lucide="shield-check"></i> Daily Briefing Archives</h2>
                 <div id="briefing-content" class="font-mono" style="text-align: center;">
-                    <p>Fetching latest intel from the grid...</p>
+                    <p>Loading archived intel packet...</p>
                     <div class="loading-dots" style="justify-content: center; margin-top: 1.5rem;">
                         <span></span>
                         <span></span>

--- a/tests/briefing.test.js
+++ b/tests/briefing.test.js
@@ -1,118 +1,15 @@
-import { test, beforeEach, after } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { onRequestGet } from '../functions/api/briefing.js';
 
-const originalFetch = globalThis.fetch;
-const originalCaches = globalThis.caches;
-
-beforeEach(() => {
-    const store = new Map();
-
-    globalThis.caches = {
-        default: {
-            async match(request) {
-                return store.get(request.url) ?? null;
-            },
-            async put(request, response) {
-                store.set(request.url, response);
-            },
-        },
-    };
-
-    globalThis.fetch = async () =>
-        new Response(
-            JSON.stringify({
-                result: {
-                    response: '### Recent Data Breaches\n* breach detail',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-});
-
-after(() => {
-    globalThis.fetch = originalFetch;
-    if (originalCaches === undefined) {
-        delete globalThis.caches;
-    } else {
-        globalThis.caches = originalCaches;
-    }
-});
-
-test('onRequestGet returns AI response payload and caches the result', async () => {
-    const waitUntilPromises = [];
-    const fetchCalls = [];
-
-    globalThis.fetch = async (...args) => {
-        fetchCalls.push(args);
-        return new Response(
-            JSON.stringify({
-                result: {
-                    response: '### Recent Data Breaches\n* breach detail',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    };
-
-    const context = {
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
-        request: new Request('https://example.com/api/briefing'),
-        waitUntil(promise) {
-            waitUntilPromises.push(promise);
-        },
-    };
-
-    const response = await onRequestGet(context);
-    assert.equal(response.status, 200);
-
-    const body = await response.clone().json();
-    assert.equal(body.markdown, '### Recent Data Breaches\n* breach detail');
-    assert.ok(typeof body.generatedAt === 'string' && body.generatedAt.length > 0);
-    assert.doesNotThrow(() => new Date(body.generatedAt));
-
-    await Promise.all(waitUntilPromises);
-
-    const cachedResponse = await caches.default.match(new Request('https://example.com/api/briefing'));
-    assert.ok(cachedResponse, 'cache should contain a cloned response');
-
-    const secondResponse = await onRequestGet({ ...context, waitUntil: () => {} });
-    assert.equal(fetchCalls.length, 1, 'AI fetch should only happen once');
-    assert.equal((await secondResponse.clone().json()).markdown, body.markdown);
-});
-
-test('onRequestGet uses default credentials when missing', async () => {
-    const calls = [];
-    globalThis.fetch = async (...args) => {
-        calls.push(args);
-        return new Response(
-            JSON.stringify({
-                result: {
-                    response: '### Recent Data Breaches\n* fallback detail',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    };
-
+test('onRequestGet returns a 410 gone notice', async () => {
     const response = await onRequestGet({
-        env: {},
         request: new Request('https://example.com/api/briefing'),
     });
 
-    assert.equal(response.status, 200);
+    assert.equal(response.status, 410);
     const payload = await response.clone().json();
-    assert.equal(payload.markdown, '### Recent Data Breaches\n* fallback detail');
-    assert.equal(
-        calls[0][0],
-        'https://api.cloudflare.com/client/v4/accounts/demo-account-id/ai/run/@cf/meta/llama-3-8b-instruct'
-    );
-    assert.equal(calls[0][1].headers.Authorization, 'Bearer demo-api-token');
+    assert.match(payload.error, /retired/i);
+    assert.match(payload.notice, /removed/i);
 });

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -1,260 +1,27 @@
-import { test, beforeEach, after } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { onRequestPost } from '../functions/api/chat.js';
 
-const originalFetch = globalThis.fetch;
-
-beforeEach(() => {
-    globalThis.fetch = async () =>
-        new Response(
-            JSON.stringify({
-                result: {
-                    response: 'Sample analyst insight',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-});
-
-after(() => {
-    globalThis.fetch = originalFetch;
-});
-
-test('onRequestPost forwards chat history and returns analyst reply', async () => {
-    const requests = [];
-    globalThis.fetch = async (input, init) => {
-        requests.push({ input, init });
-        return new Response(
-            JSON.stringify({
-                result: {
-                    response: 'Actionable response',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    };
-
+test('onRequestPost returns a 410 gone notice for POST requests', async () => {
     const request = new Request('https://example.com/api/chat', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-            messages: [
-                { role: 'user', content: 'Need mitigation advice.' },
-                { role: 'assistant', content: 'Previous answer.' },
-            ],
-        }),
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'Hello' }] }),
     });
 
-    const response = await onRequestPost({
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
-        request,
-    });
+    const response = await onRequestPost({ request });
 
-    assert.equal(response.status, 200);
+    assert.equal(response.status, 410);
     const payload = await response.clone().json();
-    assert.equal(payload.reply, 'Actionable response');
-
-    assert.equal(requests.length, 1);
-    const forwarded = JSON.parse(requests[0].init.body);
-    assert.equal(forwarded.messages[0].role, 'system');
-    assert.equal(forwarded.messages[1].role, 'user');
-    assert.equal(forwarded.messages[2].role, 'assistant');
-    assert.equal(requests[0].input, 'https://api.cloudflare.com/client/v4/accounts/acct/ai/run/@cf/meta/llama-3-8b-instruct');
+    assert.match(payload.error, /retired/i);
+    assert.match(payload.notice, /removed/i);
 });
 
-test('onRequestPost rejects invalid payloads', async () => {
-    const request = new Request('https://example.com/api/chat', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ notMessages: true }),
-    });
-
+test('onRequestPost continues to guard unsupported methods', async () => {
     const response = await onRequestPost({
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
-        request,
-    });
-
-    assert.equal(response.status, 400);
-    const payload = await response.clone().json();
-    assert.match(payload.error, /message/i);
-});
-
-test('onRequestPost falls back to default credentials when missing', async () => {
-    const calls = [];
-    globalThis.fetch = async (input, init = {}) => {
-        calls.push({ input, init });
-        return new Response(
-            JSON.stringify({
-                result: {
-                    response: 'Fallback operational.',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    };
-
-    const request = new Request('https://example.com/api/chat', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ messages: [{ role: 'user', content: 'Ping' }] }),
-    });
-
-    const response = await onRequestPost({ env: {}, request });
-
-    assert.equal(response.status, 200);
-    const payload = await response.clone().json();
-    assert.equal(payload.reply, 'Fallback operational.');
-    assert.equal(calls.length, 1);
-    assert.equal(
-        calls[0].input,
-        'https://api.cloudflare.com/client/v4/accounts/demo-account-id/ai/run/@cf/meta/llama-3-8b-instruct'
-    );
-    assert.equal(calls[0].init.headers.Authorization, 'Bearer demo-api-token');
-});
-
-test('onRequestPost surfaces upstream AI error details', async () => {
-    globalThis.fetch = async () =>
-        new Response(JSON.stringify({ errors: [{ message: 'Invalid token' }] }), {
-            status: 401,
-            statusText: 'Unauthorized',
-            headers: { 'content-type': 'application/json' },
-        });
-
-    const request = new Request('https://example.com/api/chat', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ messages: [{ role: 'user', content: 'Ping' }] }),
-    });
-
-    const response = await onRequestPost({
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
-        request,
-    });
-
-    assert.equal(response.status, 500);
-    const payload = await response.clone().json();
-    assert.match(payload.error, /Unable to retrieve analyst response/i);
-    assert.match(payload.details, /401 Unauthorized/i);
-    assert.match(payload.details, /Invalid token/i);
-});
-
-test('onRequestPost rejects unsupported methods', async () => {
-    const response = await onRequestPost({
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
         request: new Request('https://example.com/api/chat', { method: 'GET' }),
     });
 
     assert.equal(response.status, 405);
-});
-
-test('onRequestPost prefers client system prompt and removes leading assistant', async () => {
-    const requests = [];
-    globalThis.fetch = async (input, init) => {
-        requests.push({ input, init });
-        return new Response(
-            JSON.stringify({
-                result: {
-                    response: 'Ready.',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    };
-
-    const request = new Request('https://example.com/api/chat', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-            messages: [
-                { role: 'system', content: 'Use pirate voice.' },
-                { role: 'assistant', content: 'Ahoy.' },
-                { role: 'assistant', content: 'What now?' },
-                { role: 'user', content: 'Status update.' },
-            ],
-        }),
-    });
-
-    const response = await onRequestPost({
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
-        request,
-    });
-
-    assert.equal(response.status, 200);
-    const payload = JSON.parse(requests[0].init.body);
-    assert.equal(payload.messages.length, 2); // system + first user message
-    assert.equal(payload.messages[0].content, 'Use pirate voice.');
-    assert.equal(payload.messages[1].role, 'user');
-});
-
-test('onRequestPost supports custom model endpoint configuration', async () => {
-    const requests = [];
-    globalThis.fetch = async (input, init) => {
-        requests.push({ input, init });
-        return new Response(
-            JSON.stringify({
-                result: {
-                    response: 'Configured.',
-                },
-            }),
-            {
-                headers: { 'content-type': 'application/json' },
-            }
-        );
-    };
-
-    const request = new Request('https://example.com/api/chat', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ messages: [{ role: 'user', content: 'Ping' }] }),
-    });
-
-    await onRequestPost({
-        env: {
-            CLOUDFLARE_ACCOUNT_ID: 'acct',
-            CLOUDFLARE_AI_TOKEN: 'token',
-            CLOUDFLARE_AI_BASE_URL: 'https://gateway.ai.cloudflare.com/v1/acct/gateway',
-            CLOUDFLARE_AI_MODEL: '@cf/meta/llama-3-8b-instruct',
-        },
-        request,
-    });
-
-    assert.equal(requests[0].input, 'https://gateway.ai.cloudflare.com/v1/acct/gateway/@cf/meta/llama-3-8b-instruct');
-});
-
-test('onRequestPost extracts replies from OpenAI-style choices arrays', async () => {
-    globalThis.fetch = async () =>
-        new Response(
-            JSON.stringify({
-                choices: [
-                    {
-                        message: { content: 'External provider response' },
-                    },
-                ],
-            }),
-            { headers: { 'content-type': 'application/json' } }
-        );
-
-    const request = new Request('https://example.com/api/chat', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ messages: [{ role: 'user', content: 'Status update.' }] }),
-    });
-
-    const response = await onRequestPost({
-        env: { CLOUDFLARE_ACCOUNT_ID: 'acct', CLOUDFLARE_AI_TOKEN: 'token' },
-        request,
-    });
-
-    assert.equal(response.status, 200);
-    const payload = await response.clone().json();
-    assert.equal(payload.reply, 'External provider response');
 });


### PR DESCRIPTION
## Summary
- replace the daily briefing Pages Function with a 410 Gone retirement notice and update the front-end copy accordingly
- return a 410 Gone response from the chat API and disable the console UI since the live integration is removed
- refresh documentation and tests to describe the retired endpoints and notices

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5b8d2dd6c83278446749e8cead899