### PR TITLE
Align chat API CORS headers

### DIFF
--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -14,7 +14,7 @@ const CORS_HEADERS = Object.freeze({
     'content-type': 'application/json',
     'access-control-allow-origin': '*',
     'access-control-allow-methods': 'POST,OPTIONS',
-    'access-control-allow-headers': 'content-type',
+    'access-control-allow-headers': 'content-type, authorization',
 });
 
 function sanitizeMessages(rawMessages) {
@@ -86,7 +86,7 @@ export async function onRequestPost(context) {
     if (request.method !== 'POST') {
         return new Response('Method Not Allowed', {
             status: 405,
-            headers: { ...CORS_HEADERS, Allow: 'POST' },
+            headers: { ...CORS_HEADERS, Allow: 'POST, OPTIONS' },
         });
     }
 

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -155,6 +155,8 @@ test('onRequestPost rejects unsupported methods', async () => {
     });
 
     assert.equal(response.status, 405);
+    assert.equal(response.headers.get('allow'), 'POST, OPTIONS');
+    assert.match(response.headers.get('access-control-allow-headers'), /authorization/);
 });
 
 test('onRequestPost prefers client system prompt and removes leading assistant', async () => {


### PR DESCRIPTION
## Summary
- allow authorization headers on the analyst chat endpoint's CORS policy and advertise OPTIONS in 405 replies
- cover the behaviour with updated tests for unsupported methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e5ec0d935c8327821418b44f4d376d