### PR TITLE
Fix default Workers AI model compatibility

### DIFF
--- a/functions/api/briefing.js
+++ b/functions/api/briefing.js
@@ -2,7 +2,7 @@
 const PLACEHOLDER_ACCOUNT_ID = 'demo-account-id';
 const PLACEHOLDER_API_TOKEN = 'demo-api-token';
 const DEFAULT_GATEWAY = 'demo-gateway';
-const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct';
+const DEFAULT_MODEL = '@cf/meta/llama-3-8b-instruct';
 
 function resolveBriefingEndpoint(env, accountId) {
     const model = (env.CLOUDFLARE_AI_MODEL || '').trim() || DEFAULT_MODEL;

--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -5,7 +5,7 @@ const DEFAULT_SYSTEM_PROMPT = [
     'Use paragraphs or concise lists rather than markdown headings.',
 ].join(' ');
 
-const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct';
+const DEFAULT_MODEL = '@cf/meta/llama-3-8b-instruct';
 const DEFAULT_GATEWAY = 'demo-gateway';
 // Intentionally non-functional placeholders so real credentials must be supplied via env vars.
 const PLACEHOLDER_ACCOUNT_ID = 'demo-account-id';

--- a/tests/briefing.test.js
+++ b/tests/briefing.test.js
@@ -87,7 +87,7 @@ test('onRequestGet returns AI response payload and caches the result', async () 
 
     assert.equal(
         fetchCalls[0][0],
-        'https://gateway.ai.cloudflare.com/v1/acct/intel-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
+                'https://gateway.ai.cloudflare.com/v1/acct/intel-gateway/workers-ai/@cf/meta/llama-3-8b-instruct'
     );
 });
 

--- a/tests/chat.test.js
+++ b/tests/chat.test.js
@@ -66,7 +66,7 @@ test('onRequestPost forwards chat history and returns analyst reply', async () =
     assert.equal(forwarded.messages[2].role, 'assistant');
     assert.equal(
         requests[0].input,
-        'https://gateway.ai.cloudflare.com/v1/acct/my-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
+                'https://gateway.ai.cloudflare.com/v1/acct/my-gateway/workers-ai/@cf/meta/llama-3-8b-instruct'
     );
 });
 
@@ -213,14 +213,14 @@ test('onRequestPost supports custom model endpoint configuration', async () => {
             CLOUDFLARE_ACCOUNT_ID: 'acct',
             CLOUDFLARE_AI_TOKEN: 'token',
             CLOUDFLARE_AI_BASE_URL: 'https://gateway.ai.cloudflare.com/v1/acct/gateway/workers-ai',
-            CLOUDFLARE_AI_MODEL: '@cf/meta/llama-3.1-8b-instruct',
+            CLOUDFLARE_AI_MODEL: '@cf/meta/llama-3-8b-instruct',
         },
         request,
     });
 
     assert.equal(
         requests[0].input,
-        'https://gateway.ai.cloudflare.com/v1/acct/gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct'
+                'https://gateway.ai.cloudflare.com/v1/acct/gateway/workers-ai/@cf/meta/llama-3-8b-instruct'
     );
 });
 


### PR DESCRIPTION
## Summary
- switch the default Workers AI model for chat and daily briefing functions to the generally available @cf/meta/llama-3-8b-instruct
- update unit tests to match the new default endpoint slug

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6b1b726408327a1201443c166015b