### PR TITLE
Support Workers AI token fallbacks

### DIFF
--- a/docs/cloudflare-ai-configuration.md
+++ b/docs/cloudflare-ai-configuration.md
@@ -21,6 +21,8 @@ The worker expects the following environment variables:
 | `CLOUDFLARE_AI_MODEL` | (Optional) Override the default model. |
 | `CLOUDFLARE_AI_BASE_URL` | (Optional) Full URL to the gateway; otherwise the worker builds it from account + gateway. |
 
+> **Token fallback compatibility:** The worker will also accept the token via `AI_GATEWAY_API_KEY`, `CLOUDFLARE_API_TOKEN`, or `WORKERS_AI_TOKEN` environment variables. Use whichever name best matches your deployment secrets manager; the first non-empty value is used.
+
 ### Wrangler configuration (local / CI)
 
 Add the variables via `wrangler` so that local development and deployments use the correct values:

--- a/functions/api/chat.js
+++ b/functions/api/chat.js
@@ -10,6 +10,12 @@ const DEFAULT_GATEWAY = 'demo-gateway';
 // Intentionally non-functional placeholders so real credentials must be supplied via env vars.
 const PLACEHOLDER_ACCOUNT_ID = 'demo-account-id';
 const PLACEHOLDER_API_TOKEN = 'demo-api-token';
+const TOKEN_ENV_FALLBACKS = [
+    'CLOUDFLARE_AI_TOKEN',
+    'AI_GATEWAY_API_KEY',
+    'CLOUDFLARE_API_TOKEN',
+    'WORKERS_AI_TOKEN',
+];
 const CORS_HEADERS = Object.freeze({
     'content-type': 'application/json',
     'access-control-allow-origin': '*',
@@ -93,7 +99,14 @@ export async function onRequestPost(context) {
     const normalize = (value) => (typeof value === 'string' ? value.trim() : '');
 
     const accountId = normalize(env.CLOUDFLARE_ACCOUNT_ID);
-    const apiToken = normalize(env.CLOUDFLARE_AI_TOKEN);
+    const apiToken = TOKEN_ENV_FALLBACKS.reduce((selected, key) => {
+        if (selected) {
+            return selected;
+        }
+
+        const candidate = normalize(env?.[key]);
+        return candidate || '';
+    }, '');
 
     if (
         !accountId ||


### PR DESCRIPTION
## Summary
- allow the chat and briefing handlers to fall back to multiple Workers AI token environment variable names
- cover the new token fallback behaviour with unit tests
- document the accepted token aliases in the Cloudflare AI configuration guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6d7a055b88327a81facd6d24d9af2