### PR TITLE
Add weekly system news feed to homepage

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -1111,6 +1111,92 @@ body.readable-mode .fallback-notice {
     box-shadow: 0 0 18px rgba(0, 255, 136, 0.12);
 }
 
+.status-feed {
+    display: grid;
+    gap: 1.25rem;
+    margin-top: 1.25rem;
+}
+
+.status-item {
+    border: 1px solid rgba(0, 255, 136, 0.25);
+    border-radius: 0.85rem;
+    padding: 1.25rem 1.5rem;
+    background: rgba(0, 0, 0, 0.25);
+    box-shadow: 0 0 18px rgba(0, 255, 136, 0.12);
+    position: relative;
+}
+
+.status-item::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(0, 255, 136, 0.15);
+    pointer-events: none;
+    mix-blend-mode: screen;
+}
+
+.status-item-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 0.75rem;
+}
+
+.status-item-header time {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.status-item-header h3 {
+    margin: 0;
+    font-size: clamp(1.15rem, 2.1vw, 1.45rem);
+    letter-spacing: 0.08em;
+    color: rgba(204, 255, 204, 0.92);
+}
+
+.status-item p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.78);
+    line-height: 1.7;
+}
+
+.status-item-details {
+    margin: 0.85rem 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.55rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.status-item-details li {
+    display: flex;
+    gap: 0.45rem;
+    align-items: baseline;
+}
+
+.status-item-details li::before {
+    content: '▹';
+    color: var(--color-neon-primary);
+    font-size: 0.75rem;
+    margin-top: 0.15rem;
+}
+
+.status-item-detail-label {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(204, 255, 204, 0.85);
+    flex-shrink: 0;
+    min-width: 7.5rem;
+}
+
 .knowledge-callout h3 {
     margin: 0 0 0.6rem;
     font-size: clamp(1.2rem, 2.2vw, 1.6rem);

--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,71 @@
             </div>
         </section>
         <section class="cyber-panel">
+            <h2><i data-lucide="rss"></i> Operations Center System News</h2>
+            <p class="highlight">
+                Weekly situational updates from the HackTech release crew. Review the latest platform changes, infrastructure maintenance, and analyst advisories published after last week&rsquo;s deployment window.
+            </p>
+            <div class="status-feed">
+                <article class="status-item">
+                    <header class="status-item-header">
+                        <time datetime="2025-04-22">22 Apr 2025</time>
+                        <h3>Platform Release 2025.04 Goes Live</h3>
+                    </header>
+                    <p>
+                        The April release refreshes the static knowledge packs to mirror the cloud deployment completed late last week and folds in the newest tutorial cross-links highlighted in the news brief.
+                    </p>
+                    <ul class="status-item-details">
+                        <li>
+                            <span class="status-item-detail-label">Highlights</span>
+                            <span>Daily Briefing archive now references the March–April mitigation rundowns referenced in the 18 Apr news post.</span>
+                        </li>
+                        <li>
+                            <span class="status-item-detail-label">Action</span>
+                            <span>Content owners verified all `/knowledge-hub` citations and added redirects for retired tools.</span>
+                        </li>
+                    </ul>
+                </article>
+                <article class="status-item">
+                    <header class="status-item-header">
+                        <time datetime="2025-04-20">20 Apr 2025</time>
+                        <h3>Site News &amp; Intel Brief Recap</h3>
+                    </header>
+                    <p>
+                        Last week&rsquo;s analyst news release summarised credential-stuffing probes against financial SaaS tenants and called for refreshed response drills across teams.
+                    </p>
+                    <ul class="status-item-details">
+                        <li>
+                            <span class="status-item-detail-label">Mitigation</span>
+                            <span>Recommended rollout of adaptive MFA prompts to all shared consoles before 30 Apr.</span>
+                        </li>
+                        <li>
+                            <span class="status-item-detail-label">Reference</span>
+                            <span>Updated breach archive entries with latest MITRE ATT&amp;CK mappings cited in the release.</span>
+                        </li>
+                    </ul>
+                </article>
+                <article class="status-item">
+                    <header class="status-item-header">
+                        <time datetime="2025-04-19">19 Apr 2025</time>
+                        <h3>Infrastructure Maintenance Advisory</h3>
+                    </header>
+                    <p>
+                        Cloudflare Pages and Workers schedules confirmed a low-risk maintenance window following the mid-April rollout. No downtime observed, but monitoring hooks were tuned for the next cycle.
+                    </p>
+                    <ul class="status-item-details">
+                        <li>
+                            <span class="status-item-detail-label">Status</span>
+                            <span>All worker routes responded within baseline latency during the health-check sprint.</span>
+                        </li>
+                        <li>
+                            <span class="status-item-detail-label">Next</span>
+                            <span>Prepare May release notes draft with expanded system news coverage for distribution on 3 May.</span>
+                        </li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+        <section class="cyber-panel">
             <h2><i data-lucide="library"></i> Knowledge Hub &amp; Rapid Tools</h2>
             <p class="highlight">
                 Need answers fast? Jump into the Knowledge Hub for curated playbooks, cheat sheets, and tooling primers that keep analysts ready for the next escalation.


### PR DESCRIPTION
## Summary
- add an Operations Center System News section to the landing page with the latest release and infrastructure advisories
- style the new status feed cards so the updates match the existing neon panel aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68efd8c5a4b4832783c18eb7497259c5