### PR TITLE
Replace site title glitch with cyberpunk animation

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -89,35 +89,55 @@ header {
     letter-spacing: 0.35em;
     margin: 0;
     color: var(--color-neon-primary);
-    text-shadow: 0 0 12px rgba(0, 255, 136, 0.55);
+    text-shadow:
+        0 0 18px rgba(0, 255, 136, 0.4),
+        0 0 36px rgba(0, 255, 160, 0.25);
     position: relative;
     display: inline-block;
     padding: 1.35rem clamp(1.75rem, 3.5vw, 3rem);
     isolation: isolate;
     overflow: hidden;
+    animation: neon-flicker 6s ease-in-out infinite alternate;
 }
 
 .site-title::before,
 .site-title::after {
-    content: attr(data-text);
     position: absolute;
     inset: 0;
-    color: var(--color-neon-secondary);
-    mix-blend-mode: screen;
-    text-shadow: 0 0 14px rgba(0, 255, 136, 0.6);
     pointer-events: none;
 }
 
 .site-title::before {
-    animation: glitch-top 2.4s infinite steps(2, end);
-    clip-path: inset(0 0 40% 0);
-    transform: translate(-0.08em, -0.04em);
+    content: attr(data-text);
+    color: transparent;
+    background: linear-gradient(120deg,
+            rgba(0, 255, 170, 0.85) 0%,
+            rgba(64, 224, 255, 0.9) 20%,
+            rgba(255, 0, 204, 0.75) 50%,
+            rgba(255, 255, 0, 0.7) 80%,
+            rgba(0, 255, 170, 0.85) 100%);
+    background-size: 250% 250%;
+    background-position: 0% 50%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    mix-blend-mode: screen;
+    filter: drop-shadow(0 0 1.75rem rgba(0, 255, 190, 0.55));
+    animation: cyber-gradient 8s linear infinite;
 }
 
 .site-title::after {
-    animation: glitch-bottom 2.4s infinite steps(2, end);
-    clip-path: inset(60% 0 0 0);
-    transform: translate(0.08em, 0.04em);
+    content: "";
+    inset: -25% -30%;
+    background:
+        radial-gradient(circle at 30% 20%, rgba(0, 255, 191, 0.25), transparent 55%),
+        radial-gradient(circle at 70% 80%, rgba(255, 0, 170, 0.2), transparent 50%),
+        repeating-linear-gradient(
+            rgba(0, 255, 225, 0.14) 0 2px,
+            rgba(0, 0, 0, 0) 2px 6px
+        );
+    mix-blend-mode: screen;
+    opacity: 0.75;
+    animation: scanline 3.5s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -126,47 +146,51 @@ header {
         animation: none;
         transform: none;
     }
-}
-
-@keyframes glitch-top {
-    0% {
-        transform: translate(-0.08em, -0.04em);
-    }
-    20% {
-        transform: translate(0.12em, -0.02em);
-    }
-    40% {
-        transform: translate(-0.16em, -0.08em);
-    }
-    60% {
-        transform: translate(0.08em, -0.06em);
-    }
-    80% {
-        transform: translate(-0.12em, -0.02em);
-    }
-    100% {
-        transform: translate(-0.08em, -0.04em);
+    .site-title {
+        animation: none;
     }
 }
 
-@keyframes glitch-bottom {
+@keyframes cyber-gradient {
     0% {
-        transform: translate(0.08em, 0.04em);
+        background-position: 0% 50%;
     }
-    20% {
-        transform: translate(-0.1em, 0.02em);
-    }
-    40% {
-        transform: translate(0.14em, 0.08em);
-    }
-    60% {
-        transform: translate(-0.06em, 0.06em);
-    }
-    80% {
-        transform: translate(0.12em, 0.02em);
+    50% {
+        background-position: 100% 50%;
     }
     100% {
-        transform: translate(0.08em, 0.04em);
+        background-position: 0% 50%;
+    }
+}
+
+@keyframes scanline {
+    0% {
+        background-position: 0% -40%;
+    }
+    100% {
+        background-position: 0% 140%;
+    }
+}
+
+@keyframes neon-flicker {
+    0%,
+    18%,
+    22%,
+    25%,
+    53%,
+    57%,
+    100% {
+        text-shadow:
+            0 0 18px rgba(0, 255, 136, 0.45),
+            0 0 38px rgba(0, 255, 180, 0.35),
+            0 0 62px rgba(0, 255, 210, 0.25);
+    }
+    20%,
+    24%,
+    55% {
+        text-shadow:
+            0 0 8px rgba(0, 255, 136, 0.2),
+            0 0 24px rgba(0, 255, 160, 0.18);
     }
 }
 


### PR DESCRIPTION
## Summary
- restyle the hero title with a neon gradient glow and scanline overlay for a cyberpunk vibe
- add new animation keyframes while respecting prefers-reduced-motion fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f074c938408327b1988de18a5b86e3