### PR TITLE
Update chat console branding

### DIFF
--- a/public/chat-console.html
+++ b/public/chat-console.html
@@ -36,7 +36,7 @@
             </button>
         </nav>
         <section class="cyber-panel" aria-labelledby="chat-console-heading">
-            <h2 id="chat-console-heading"><i data-lucide="messages-square"></i> Analyst Chat Console</h2>
+            <h2 id="chat-console-heading"><i data-lucide="messages-square"></i> AI Chat (Free Version)</h2>
             <p class="highlight">
                 The live analyst feed has been retired while Cloudflare Workers AI access is offline. The console now returns archived guidance so you can reference past playbooks and workflows while the real-time integration is rebuilt.
             </p>

--- a/public/daily-briefing.html
+++ b/public/daily-briefing.html
@@ -50,7 +50,7 @@
             </section>
 
             <section class="cyber-panel" id="analyst-chat" aria-labelledby="analyst-chat-heading">
-                <h2 id="analyst-chat-heading"><i data-lucide="messages-square"></i> Analyst Chat Console</h2>
+                <h2 id="analyst-chat-heading"><i data-lucide="messages-square"></i> AI Chat (Free Version)</h2>
                 <div class="chat-wrapper" data-chat-wrapper>
                     <div class="chat-thread" id="chat-thread" aria-live="polite" aria-busy="false"></div>
                     <form id="chat-form" class="chat-form" autocomplete="off">

--- a/public/index.html
+++ b/public/index.html
@@ -138,7 +138,7 @@
             </p>
             <div class="grid grid-two">
                 <a class="data-card" href="/chat-console.html">
-                    <h3 class="font-mono" style="color: var(--color-neon-primary); letter-spacing: 0.1em;">Analyst Chat Console</h3>
+                    <h3 class="font-mono" style="color: var(--color-neon-primary); letter-spacing: 0.1em;">AI Chat (Free Version)</h3>
                     <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem;">Link up with the embedded analyst for rapid threat triage, mitigation advice, and tool selection guidance.</p>
                 </a>
                 <a class="data-card" href="/ethical-hacking-tutorials.html">


### PR DESCRIPTION
## Summary
- rename the Analyst Chat Console heading to "AI Chat (Free Version)" across the chat experiences

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68f07648393c8327b7a8db33f8957a32