### PR TITLE
Revamp homepage hero with case studies and CTAs

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -213,6 +213,212 @@ body.readable-mode .cta-button:focus-visible {
     box-shadow: 0 0 18px rgba(59, 130, 246, 0.45);
 }
 
+.hero-panel {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.hero-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.hero-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.hero-lede {
+    font-size: 1.05rem;
+    line-height: 1.8;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.hero-primary {
+    background: linear-gradient(135deg, rgba(0, 255, 136, 0.45), rgba(0, 255, 136, 0.15));
+    color: #001b0b;
+}
+
+.hero-primary:hover,
+.hero-primary:focus-visible {
+    color: #001b0b;
+}
+
+.hero-secondary {
+    border-color: rgba(148, 163, 184, 0.45);
+    background: rgba(10, 17, 35, 0.5);
+    color: rgba(226, 232, 240, 0.85);
+    box-shadow: none;
+}
+
+.hero-secondary:hover,
+.hero-secondary:focus-visible {
+    background: rgba(15, 23, 42, 0.7);
+    color: var(--color-neon-primary);
+    box-shadow: 0 0 12px rgba(0, 255, 136, 0.25);
+}
+
+.credibility-panel {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.credential-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+}
+
+.credential-badge {
+    padding: 0.4rem 1.1rem;
+    border: 1px solid rgba(56, 189, 248, 0.5);
+    border-radius: 999px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    background: rgba(15, 23, 42, 0.6);
+    box-shadow: 0 0 14px rgba(56, 189, 248, 0.25);
+}
+
+.logo-strip {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+    text-align: center;
+}
+
+.logo-strip-label {
+    font-size: 0.8rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.logo-strip-list {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+    padding: 0;
+    margin: 0;
+}
+
+.logo-strip-list li {
+    padding: 0.55rem 1.2rem;
+    border-radius: 0.75rem;
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.sample-report-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.sample-report-card {
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(10, 17, 35, 0.55);
+    padding: 1.5rem;
+    border-radius: 1rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.sample-report-card h3 {
+    font-size: 0.95rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--color-neon-primary);
+}
+
+.case-study-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.case-study-card {
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(10, 17, 35, 0.55);
+    padding: 1.75rem;
+    border-radius: 1rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.case-study-card header h3 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.case-study-card header p {
+    margin: 0.35rem 0 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.55);
+}
+
+.case-study-card dl {
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.case-study-card dt {
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-neon-primary);
+    margin-bottom: 0.35rem;
+}
+
+.case-study-card dd {
+    margin: 0;
+    line-height: 1.7;
+    color: rgba(226, 232, 240, 0.9);
+}
+
+@media (max-width: 768px) {
+    .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .logo-strip-list {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .sample-report-grid,
+    .case-study-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (min-width: 769px) {
+    .sample-report-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .case-study-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
 body.readable-mode .nav-link:hover {
     color: var(--color-readable-accent);
     border-color: rgba(59, 130, 246, 0.55);

--- a/public/daily-briefing.html
+++ b/public/daily-briefing.html
@@ -39,12 +39,15 @@
         <div class="briefing-layout">
             <section class="cyber-panel" aria-labelledby="daily-briefing-heading">
                 <h2 id="daily-briefing-heading"><i data-lucide="shield-check"></i> Daily Briefing Archives</h2>
-                <div id="briefing-content" class="font-mono" style="text-align: center;">
-                    <p>Loading archived intel packet...</p>
-                    <div class="loading-dots" style="justify-content: center; margin-top: 1.5rem;">
-                        <span></span>
-                        <span></span>
-                        <span></span>
+                <div id="briefing-content" class="font-mono" style="text-align: left;">
+                    <div class="data-card">
+                        <div class="briefing-meta font-mono">
+                            <span class="meta-pill">Feed retired</span>
+                        </div>
+                        <p class="briefing-paragraph">
+                            The automated daily briefing is offline and no longer pulls from Cloudflare Workers AI. Explore the tutorials,
+                            breach archives, and knowledge hub pages for training material instead.
+                        </p>
                     </div>
                 </div>
             </section>

--- a/public/index.html
+++ b/public/index.html
@@ -34,20 +34,127 @@
                 <i data-lucide="contrast"></i> <span data-theme-toggle-label>Accessibility Mode: Off</span>
             </button>
         </nav>
-        <section class="cyber-panel">
-            <h2><i data-lucide="activity"></i> Welcome to the Cyber Frontier</h2>
-            <p class="highlight">
-                HackTech is your real-time feed for cyber intelligence. We provide educational insights into vulnerabilities, defensive strategies, and the ongoing struggle for digital security. Stay informed, stay secure.
+        <section class="cyber-panel hero-panel">
+            <div class="hero-header">
+                <p class="hero-eyebrow font-mono">Israel-based offensive security team</p>
+                <h2><i data-lucide="activity"></i> Offensive security &amp; training for startups and SMBs</h2>
+            </div>
+            <p class="highlight hero-lede">
+                Web, mobile, and cloud pentests delivered with prioritized, easy-to-ship fixes in 10 days. We embed with founders and engineering leads to close exploitable gaps before they become customer-facing incidents.
             </p>
-            <div class="grid grid-two">
-                <a class="data-card" href="/daily-briefing.html">
-                    <h3 class="font-mono" style="color: var(--color-neon-primary); letter-spacing: 0.1em;">Daily Briefing</h3>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem;">Get today's AI-generated summary of global cyber threats, new tools, and critical vulnerabilities.</p>
+            <div class="hero-actions">
+                <a class="cta-button hero-primary" href="/contact.html">
+                    <span>Book a consult</span>
+                    <i data-lucide="calendar"></i>
                 </a>
-                <a class="data-card" href="/breach-archives.html">
-                    <h3 class="font-mono" style="color: var(--color-neon-primary); letter-spacing: 0.1em;">Breach Archives</h3>
-                    <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem;">Learn from the past. We dissect major historical data breaches to understand their impact and prevention.</p>
+                <a class="cta-button hero-secondary" href="#sample-report">
+                    <span>See sample report</span>
+                    <i data-lucide="file-text"></i>
                 </a>
+            </div>
+        </section>
+
+        <section class="cyber-panel credibility-panel">
+            <div class="credential-badges" aria-label="Professional certifications">
+                <span class="credential-badge">OSCP</span>
+                <span class="credential-badge">CEH</span>
+                <span class="credential-badge">eJPT</span>
+            </div>
+            <div class="logo-strip" aria-label="Client collaborations">
+                <span class="logo-strip-label font-mono">Worked with:</span>
+                <ul class="logo-strip-list">
+                    <li>Tel Aviv Fintech Hub</li>
+                    <li>Horizon Agritech</li>
+                    <li>Galilee Mobility Labs</li>
+                    <li>MedShield Startups</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="cyber-panel" id="sample-report">
+            <h2><i data-lucide="file-text"></i> Sample remediation report excerpt</h2>
+            <p class="highlight">
+                Every engagement ships with executive-ready summaries, developer reproduction steps, and validated fixes. Here&rsquo;s an excerpt from a recent SaaS pentest package.
+            </p>
+            <div class="sample-report-grid">
+                <article class="sample-report-card">
+                    <h3 class="font-mono">Finding</h3>
+                    <p>Critical IDOR in customer billing API exposed invoice metadata for unauthenticated users.</p>
+                </article>
+                <article class="sample-report-card">
+                    <h3 class="font-mono">Exploit Path</h3>
+                    <p>Demonstrated via Postman collection with replay-safe tokens and annotated screenshots for each request sequence.</p>
+                </article>
+                <article class="sample-report-card">
+                    <h3 class="font-mono">Remediation</h3>
+                    <p>Implemented tenant-scoped authorization middleware and contract tests. Fix validated within 48 hours and regression automation provided.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="cyber-panel" id="case-studies">
+            <h2><i data-lucide="briefcase"></i> Redacted case studies</h2>
+            <div class="case-study-grid">
+                <article class="case-study-card">
+                    <header>
+                        <h3>Seed-stage fintech platform</h3>
+                        <p class="font-mono">Problem &rarr; Approach &rarr; Impact</p>
+                    </header>
+                    <dl>
+                        <div>
+                            <dt>Problem</dt>
+                            <dd>Investors requested proof of secure payment flows before Series A. Internal QA lacked adversarial testing capability.</dd>
+                        </div>
+                        <div>
+                            <dt>Approach</dt>
+                            <dd>Executed 9-day web and mobile assessment with OWASP ASVS mapping, plus tabletop review of fraud escalation paths with product owners.</dd>
+                        </div>
+                        <div>
+                            <dt>Impact</dt>
+                            <dd>Closed 6 high-risk findings, shipped MFA rollout plan, and supplied investor-ready assurance memo that accelerated the funding round.</dd>
+                        </div>
+                    </dl>
+                </article>
+                <article class="case-study-card">
+                    <header>
+                        <h3>Healthcare IoT vendor</h3>
+                        <p class="font-mono">Problem &rarr; Approach &rarr; Impact</p>
+                    </header>
+                    <dl>
+                        <div>
+                            <dt>Problem</dt>
+                            <dd>Hospital clients flagged device API downtime caused by unauthenticated configuration endpoints.</dd>
+                        </div>
+                        <div>
+                            <dt>Approach</dt>
+                            <dd>Performed cloud review and firmware analysis, then paired with DevOps to harden IAM policies and implement signed command validation.</dd>
+                        </div>
+                        <div>
+                            <dt>Impact</dt>
+                            <dd>Eliminated anonymous control access, reduced false alarms by 72%, and secured renewal of the vendor&rsquo;s largest hospital contract.</dd>
+                        </div>
+                    </dl>
+                </article>
+                <article class="case-study-card">
+                    <header>
+                        <h3>Logistics SaaS scale-up</h3>
+                        <p class="font-mono">Problem &rarr; Approach &rarr; Impact</p>
+                    </header>
+                    <dl>
+                        <div>
+                            <dt>Problem</dt>
+                            <dd>Customer trust team detected suspicious partner logins with elevated privileges and needed external validation before launch in the EU.</dd>
+                        </div>
+                        <div>
+                            <dt>Approach</dt>
+                            <dd>Delivered purple-team engagement combining adversarial simulations, SCIM provisioning audit, and training workshops for support engineers.</dd>
+                        </div>
+                        <div>
+                            <dt>Impact</dt>
+                            <dd>Hardened partner SSO, cut privilege misuse alerts by 60%, and trained 45 staff on rapid triage playbooks ahead of EU go-live.</dd>
+                        </div>
+                    </dl>
+                </article>
             </div>
         </section>
         <section class="cyber-panel">


### PR DESCRIPTION
## Summary
- rewrite the homepage hero to target Israeli startup security buyers and add clear consult/sample report calls-to-action
- add certification badges, client logo strip, and a sample remediation excerpt to highlight deliverables
- publish three redacted case studies and ensure the daily briefing page immediately shows its retirement notice

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f132bce15c8327a8e87c9934d6a558