### PR TITLE
Retitle breach archives page to Android Hacking

### DIFF
--- a/public/breach-archives.html
+++ b/public/breach-archives.html
@@ -35,7 +35,11 @@
             </button>
         </nav>
         <section class="cyber-panel">
-            <h2><i data-lucide="shield-alert"></i> Breach Archives: Case Studies</h2>
+            <h2 style="display: flex; align-items: center; gap: 0.6rem; font-size: 1.9rem;">
+                <i data-lucide="bot" style="color: #ff4d6d; transform: rotate(-12deg);"></i>
+                Android Hacking
+            </h2>
+            <p class="font-mono" style="color: rgba(255,255,255,0.6); font-size: 0.95rem; letter-spacing: 0.2em; margin-bottom: 1.75rem;">(Nethunter)</p>
             <article class="data-card" style="margin-bottom: 1.5rem;">
                 <h3 class="font-mono" style="color: rgba(204,255,204,0.95); font-size: 1.25rem;">&gt;&gt; Case Study: The Equifax Breach (2017)</h3>
                 <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.9rem; line-height: 1.7;">


### PR DESCRIPTION
## Summary
- replace the Breach Archives heading with an Android Hacking title and stylized bot icon
- add a Nethunter subtitle beneath the heading for additional context

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f07a48d1f48327bed79172322d866b