### PR TITLE
Update contact email references to admin@hack-tech.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://www.linkedin.com/in/freespirits"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?logo=linkedin&logoColor=white"></a>
-  <a href="mailto:security@freespirits.io"><img alt="Email" src="https://img.shields.io/badge/Contact-security@freespirits.io-black"></a>
+  <a href="mailto:admin@hack-tech.org"><img alt="Email" src="https://img.shields.io/badge/Contact-admin@hack--tech.org-black"></a>
   <a href="https://keybase.io/freespirits"><img alt="PGP" src="https://img.shields.io/badge/PGP-verify-313131"></a>
   <img alt="Hire" src="https://img.shields.io/badge/Availability-Engagements%20Open-success">
   <img alt="Ethics" src="https://img.shields.io/badge/Ethical-Yes-brightgreen">
@@ -77,7 +77,7 @@ Scripting: `Python`/`Go` + custom one-offs in `Tools/`
 
 ## Responsible Disclosure
 I follow **coordinated disclosure**. For vendors/programs:
-1. Email **security@freespirits.io** (PGP below) with steps and impact.  
+1. Email **admin@hack-tech.org** (PGP below) with steps and impact.
 2. I avoid data retention and use minimal proof data.  
 3. 90-day default window unless agreed otherwise.
 
@@ -112,7 +112,7 @@ I follow **coordinated disclosure**. For vendors/programs:
 ---
 
 ## Contact
-- **Email:** security@freespirits.io
+- **Email:** admin@hack-tech.org
 - **Signal:** +44 7123 456789 (on request)
 - **PGP:** see “Responsible Disclosure”
 - **Booking:** [https://calendly.com/freespirits/consult](https://calendly.com/freespirits/consult)

--- a/docs/site-operations-conflicts.md
+++ b/docs/site-operations-conflicts.md
@@ -16,8 +16,8 @@ The following production-impacting conflicts are present in the Worker and Pages
 - **Action:** Configure `MIDJOURNEY_PROXY_URL` in the Pages/Worker environment to restore `/api/midjourney/*` routing.
 
 ## Contact relay defaults
-- The contact form handler hard-codes `CONTACT_TO_EMAIL` to `hoya282@gmail.com` whenever the environment variable is missing.【F:functions/api/contact.js†L1-L88】
-- **Action:** Provide the correct destination email (for example, `security@freespirits.io`) via environment variables to avoid misrouting sensitive inquiries.
+- The contact form handler hard-codes `CONTACT_TO_EMAIL` to `admin@hack-tech.org` whenever the environment variable is missing.【F:functions/api/contact.js†L1-L88】
+- **Action:** Provide the correct destination email (for example, `admin@hack-tech.org`) via environment variables to avoid misrouting sensitive inquiries.
 
 ---
 

--- a/functions/api/contact.js
+++ b/functions/api/contact.js
@@ -12,7 +12,7 @@ export const onRequestPost = async ({ request, env }) => {
             }, 400, request);
         }
 
-        const toEmail = (env.CONTACT_TO_EMAIL || 'hoya282@gmail.com').trim();
+        const toEmail = (env.CONTACT_TO_EMAIL || 'admin@hack-tech.org').trim();
         if (!toEmail) {
             return createResponse({
                 status: 'error',

--- a/public/contact.html
+++ b/public/contact.html
@@ -42,7 +42,7 @@
             </p>
             <div class="data-card" style="margin-bottom: 2rem;">
                 <p class="font-mono" style="color: rgba(255,255,255,0.75); font-size: 0.85rem; line-height: 1.7;">
-                    <strong class="text-strong">Form integration tip:</strong> Messages are routed through our Cloudflare Pages Function and delivered via MailChannels. Update the <code>CONTACT_TO_EMAIL</code> environment variable to point at your preferred inbox—defaults to <code>hoya282@gmail.com</code>.
+                    <strong class="text-strong">Form integration tip:</strong> Messages are routed through our Cloudflare Pages Function and delivered via MailChannels. Update the <code>CONTACT_TO_EMAIL</code> environment variable to point at your preferred inbox—defaults to <code>admin@hack-tech.org</code>.
                 </p>
             </div>
             <form action="/api/contact" method="POST" data-contact-form>


### PR DESCRIPTION
## Summary
- replace the default contact relay destination with admin@hack-tech.org
- update static contact page copy to reflect the new default email
- refresh repository documentation to reference admin@hack-tech.org for inquiries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2002be9d483279f2e51f4d77774f8