### PR TITLE
Add mirror download link for VMware Workstation

### DIFF
--- a/public/vmware-practice-lab.html
+++ b/public/vmware-practice-lab.html
@@ -82,6 +82,8 @@
                 <h3>Need the Windows build?</h3>
                 <p>Download VMware Workstation Pro directly from VMware for Windows hosts to begin building the lab immediately.</p>
                 <a class="cta-button" href="https://www.vmware.com/go/getworkstation-win" target="_blank" rel="noopener noreferrer">Download Workstation Pro for Windows</a>
+                <p class="resource-note">Need a mirror? Grab the current installer build directly:</p>
+                <a class="cta-button" href="https://de1-dl.techpowerup.com/files/WEwZRTkAirWoRXuIsKussw/1760742802/VMware-workstation-full-17.6.4-24832109.exe" target="_blank" rel="noopener noreferrer">Download Workstation Pro 17.6.4 (Mirror)</a>
             </div>
             <div class="resource-section">
                 <h3>Deployment Flow</h3>


### PR DESCRIPTION
## Summary
- add a mirror download option for VMware Workstation Pro within the practice lab guide
- provide a direct link to the latest Windows installer build alongside the official VMware download

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f326be8f808327bad898634c87445e