### PR TITLE
Add Facebook domain verification meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="facebook-domain-verification" content="8jauzpukwjv3cnzsoaf052ajs262c2" />
     <title>Hack Tech</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- Adds `<meta name="facebook-domain-verification" content="8jauzpukwjv3cnzsoaf052ajs262c2" />` to the `<head>` of `public/index.html` so Meta can verify ownership of hack-tech.org.

No prior `facebook-domain-verification` meta tag was present in the repo, so nothing needed to be removed.

## Test plan
- [ ] Deploy and visit http://hack-tech.org/, view source, confirm the meta tag is present inside `<head>`.
- [ ] Run Meta's domain verification check.

---
_Generated by [Claude Code](https://claude.ai/code/session_018976uAP1ygsZCqUQdbnbBb)_